### PR TITLE
Improve OOP interface

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -746,6 +746,22 @@ class HGVS
 
 
 
+    public function isAVariant ()
+    {
+        // Returns true if we have some kind of variant here, false otherwise.
+        return (
+            $this->hasMatched()
+            && (
+                (get_class($this) == 'HGVS' && in_array($this->getMatchedPattern(), ['full_variant', 'variant']))
+                || (get_class($this) == 'HGVS_Variant' && $this->hasMatched())
+            )
+        );
+    }
+
+
+
+
+
     public function isTheCaseOK ()
     {
         return $this->caseOK;

--- a/HGVS.php
+++ b/HGVS.php
@@ -343,6 +343,10 @@ class HGVS
             unset($this->messages['EREFSEQMISSING']);
             // Rebuild the info just in case.
             $this->buildInfo();
+
+        } else {
+            // In case there is a reference sequence, and we complain about it, remove that complaint.
+            unset($this->messages['WREFSEQGIVEN']);
         }
 
         return true;
@@ -833,7 +837,7 @@ class HGVS
 
         } else {
             // Unset the error in case we had it.
-            unset($this->messages['EREFSEQMISSING']);
+            unset($this->messages['EREFSEQMISSING'], $this->messages['IREFSEQMISSING']);
         }
         // Rebuild the info just in case.
         $this->buildInfo();

--- a/HGVS.php
+++ b/HGVS.php
@@ -437,39 +437,6 @@ class HGVS
 
 
 
-    public function buildInfo ()
-    {
-        // Builds the info array.
-        $this->info = array_merge(
-            $this->data,
-            [
-                'messages' => [],
-                'warnings' => [],
-                'errors' => [],
-            ]
-        );
-        foreach ($this->getMessages() as $sCode => $sMessage) {
-            switch (substr($sCode, 0, 1)) {
-                case 'E':
-                    $this->info['errors'][$sCode] = $sMessage;
-                    break;
-                case 'W':
-                    $this->info['warnings'][$sCode] = $sMessage;
-                    break;
-                case 'I':
-                default:
-                    $this->info['messages'][$sCode] = $sMessage;
-                    break;
-            }
-        }
-
-        return $this->info;
-    }
-
-
-
-
-
     public static function create ($sInput)
     {
         // Creates a new instance of this class.
@@ -567,7 +534,10 @@ class HGVS
 
     public function getInfo ()
     {
-        return $this->buildInfo();
+        return array_merge(
+            $this->data,
+            $this->getMessagesByGroup()
+        );
     }
 
 
@@ -604,6 +574,37 @@ class HGVS
     public function getMessages ()
     {
         return ($this->messages ?? []);
+    }
+
+
+
+
+
+    public function getMessagesByGroup ()
+    {
+        // Get the messages, grouped by type.
+        $aMessages = [
+            'messages' => [],
+            'warnings' => [],
+            'errors' => [],
+        ];
+
+        foreach ($this->getMessages() as $sCode => $sMessage) {
+            switch (substr($sCode, 0, 1)) {
+                case 'E':
+                    $aMessages['errors'][$sCode] = $sMessage;
+                    break;
+                case 'W':
+                    $aMessages['warnings'][$sCode] = $sMessage;
+                    break;
+                case 'I':
+                default:
+                    $aMessages['messages'][$sCode] = $sMessage;
+                    break;
+            }
+        }
+
+        return $aMessages;
     }
 
 
@@ -830,8 +831,8 @@ class HGVS
         }
 
         return (
-            empty(array_diff_key($this->getInfo()['errors'], array_flip(['ENOTSUPPORTED'])))
-            && empty(array_diff_key($this->getInfo()['warnings'], array_flip(['WNOTSUPPORTED', 'WREFERENCENOTSUPPORTED']))));
+            empty(array_diff_key($this->getMessagesByGroup()['errors'], array_flip(['ENOTSUPPORTED'])))
+            && empty(array_diff_key($this->getMessagesByGroup()['warnings'], array_flip(['WNOTSUPPORTED', 'WREFERENCENOTSUPPORTED']))));
     }
 
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -532,13 +532,43 @@ class HGVS
 
 
 
+    public function getIdentifiedAs ()
+    {
+        // Return some kind of description of what we are, based on matched patterns.
+        // Example outputs: "reference_sequence", "full_variant", "variant_DNA_predicted", etc.
+        $sReturn = $this->getMatchedPattern();
+        if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
+            $sReturn .= '_' . $this->Variant->getMatchedPattern();
+        }
+        return $sReturn;
+    }
+
+
+
+
+
+    public function getIdentifiedAsFormatted ()
+    {
+        // Return some kind of description of what we are, based on matched patterns, formatted for humans.
+        // Example outputs: "reference sequence", "full variant", "variant (DNA, predicted)", etc.
+        $sReturn = $this->getMatchedPatternFormatted();
+        if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
+            $sReturn .= ' (' . str_replace('_', ', ', $this->Variant->getMatchedPattern()) . ')';
+        }
+        return $sReturn;
+    }
+
+
+
+
+
     public function getInfo ()
     {
         return array_merge(
             [
                 'input' => $this->getInput(),
-                'identified_as' => $this->isA(),
-                'identified_as_formatted' => $this->isAFormatted(),
+                'identified_as' => $this->getIdentifiedAs(),
+                'identified_as_formatted' => $this->getIdentifiedAsFormatted(),
                 'valid' => $this->isValid(),
             ],
             $this->getMessagesByGroup(),
@@ -751,36 +781,6 @@ class HGVS
 
 
 
-    public function isA ()
-    {
-        // Return some kind of description of what we are, based on matched patterns.
-        // Example outputs: "reference_sequence", "full_variant", "variant_DNA_predicted", etc.
-        $sReturn = $this->getMatchedPattern();
-        if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
-            $sReturn .= '_' . $this->Variant->getMatchedPattern();
-        }
-        return $sReturn;
-    }
-
-
-
-
-
-    public function isAFormatted ()
-    {
-        // Return some kind of description of what we are, based on matched patterns, formatted for humans.
-        // Example outputs: "reference sequence", "full variant", "variant (DNA, predicted)", etc.
-        $sReturn = $this->getMatchedPatternFormatted();
-        if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
-            $sReturn .= ' (' . str_replace('_', ', ', $this->Variant->getMatchedPattern()) . ')';
-        }
-        return $sReturn;
-    }
-
-
-
-
-
     public function isAVariant ()
     {
         // Returns true if we have some kind of variant here, false otherwise.
@@ -880,7 +880,7 @@ class HGVS
         // Requires that the input is a variant. Otherwise, the input is regarded as not valid.
 
         if (!$this->isAVariant()) {
-            $sType = $this->isAFormatted();
+            $sType = $this->getIdentifiedAsFormatted();
             $this->messages['EVARIANTREQUIRED'] = 'This input requires a variant description' . (!$sType? '.' : '; ' . $sType . ' given.');
         }
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-02-11   // When modified, also change the library_version.
+ * Modified    : 2025-02-12   // When modified, also change the library_version.
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -737,7 +737,7 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_version' => '2025-02-11',
+            'library_version' => '2025-02-12',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',
@@ -786,9 +786,8 @@ class HGVS
         // Returns true if we have some kind of variant here, false otherwise.
         return (
             $this->hasMatched()
-            && (
-                (get_class($this) == 'HGVS' && in_array($this->getMatchedPattern(), ['full_variant', 'variant']))
-                || (get_class($this) == 'HGVS_Variant' && $this->hasMatched())
+            && (get_class($this) == 'HGVS_Variant'
+                || (get_class($this) == 'HGVS' && in_array($this->getMatchedPattern(), ['full_variant', 'variant']))
             )
         );
     }

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-31   // When modified, also change the library_version.
+ * Modified    : 2025-02-10   // When modified, also change the library_version.
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -681,7 +681,7 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_version' => '2025-01-31',
+            'library_version' => '2025-02-10',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',
@@ -710,6 +710,21 @@ class HGVS
         // This function checks if this class has a property called $sClassName.
         // A property is a matched object, stored in the $this->properties array.
         return ($this->properties && is_array($this->properties) && in_array($sClassName, $this->properties));
+    }
+
+
+
+
+
+    public function isA ()
+    {
+        // Return some kind of description of what we are, based on matched patterns.
+        // Example outputs: "reference_sequence", "full_variant", "variant_DNA_predicted", etc.
+        $sReturn = $this->getMatchedPattern();
+        if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
+            $sReturn .= '_' . $this->Variant->getMatchedPattern();
+        }
+        return $sReturn;
     }
 
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -731,6 +731,21 @@ class HGVS
 
 
 
+    public function isAFormatted ()
+    {
+        // Return some kind of description of what we are, based on matched patterns, formatted for humans.
+        // Example outputs: "reference sequence", "full variant", "variant (DNA, predicted)", etc.
+        $sReturn = $this->getMatchedPatternFormatted();
+        if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
+            $sReturn .= ' (' . str_replace('_', ', ', $this->Variant->getMatchedPattern()) . ')';
+        }
+        return $sReturn;
+    }
+
+
+
+
+
     public function isTheCaseOK ()
     {
         return $this->caseOK;

--- a/HGVS.php
+++ b/HGVS.php
@@ -349,7 +349,7 @@ class HGVS
             unset($this->messages['WREFSEQGIVEN']);
         }
 
-        return true;
+        return $this;
     }
 
 
@@ -467,6 +467,19 @@ class HGVS
         }
 
         return $this->info;
+    }
+
+
+
+
+
+    public static function create ($sInput)
+    {
+        // Creates a new instance of this class.
+        // The advantage of using this over "new HGVS(...)" is that we can combine instructions, like:
+        // $HGVS = HGVS::create($sVariant)->requireVariant()->allowMissingReferenceSequence().
+
+        return new static($sInput);
     }
 
 
@@ -842,7 +855,7 @@ class HGVS
         // Rebuild the info just in case.
         $this->buildInfo();
 
-        return true;
+        return $this;
     }
 
 
@@ -860,7 +873,7 @@ class HGVS
         // Rebuild the info just in case.
         $this->buildInfo();
 
-        return true;
+        return $this;
     }
 
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-02-10   // When modified, also change the library_version.
+ * Modified    : 2025-02-11   // When modified, also change the library_version.
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -535,8 +535,17 @@ class HGVS
     public function getInfo ()
     {
         return array_merge(
-            $this->data,
-            $this->getMessagesByGroup()
+            [
+                'input' => $this->getInput(),
+                'identified_as' => $this->isA(),
+                'identified_as_formatted' => $this->isAFormatted(),
+                'valid' => $this->isValid(),
+            ],
+            $this->getMessagesByGroup(),
+            [
+                'data' => $this->getData(),
+                'corrected_values' => $this->getCorrectedValues(),
+            ]
         );
     }
 
@@ -698,7 +707,7 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_version' => '2025-02-10',
+            'library_version' => '2025-02-11',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',

--- a/HGVS.php
+++ b/HGVS.php
@@ -437,11 +437,11 @@ class HGVS
 
 
 
-    public static function create ($sInput)
+    public static function check ($sInput)
     {
-        // Creates a new instance of this class.
+        // Creates a new instance of this class, checking the input.
         // The advantage of using this over "new HGVS(...)" is that we can combine instructions, like:
-        // $HGVS = HGVS::create($sVariant)->requireVariant()->allowMissingReferenceSequence().
+        // $HGVS = HGVS::check($sVariant)->requireVariant()->allowMissingReferenceSequence().
 
         return new static($sInput);
     }

--- a/HGVS.php
+++ b/HGVS.php
@@ -849,6 +849,24 @@ class HGVS
 
 
 
+    public function requireVariant ()
+    {
+        // Requires that the input is a variant. Otherwise, the input is regarded as not valid.
+
+        if (!$this->isAVariant()) {
+            $sType = $this->isAFormatted();
+            $this->messages['EVARIANTREQUIRED'] = 'This input requires a variant description' . (!$sType? '.' : '; ' . $sType . ' given.');
+        }
+        // Rebuild the info just in case.
+        $this->buildInfo();
+
+        return true;
+    }
+
+
+
+
+
     public function setCorrectedValue ($sValue, $nConfidence = 1)
     {
         // Conveniently sets the corrected value for us.


### PR DESCRIPTION
### Improve the OOP interface, preparing for writing the documentation

- Add `getIdentifiedAs()`, which informs the user what we actually found. Example outputs: "reference_sequence", "full_variant", "variant_DNA_predicted", etc.
- Add `getIdentifiedAsFormatted()`, a formatted version of `getIdentifiedAs()`.
- Add `isAVariant()`, which returns `True` if we matched a variant. This will allow users to quickly check whether they have a variant, instead of having to parse the output of `getIdentifiedAs()`.
- Solve issues with combining reference sequence-related methods. When the two methods `allowMissingReferenceSequence()` and `requireMissingReferenceSequence()` are used in combination, make sure only the last one takes precedence.
- Add `requireVariant()`, which makes sure the input has to be a variant. If not, an error is thrown, invalidating the input.
- Add a static method to create a new instance of the HGVS class. That way, we can combine initializing the class with instructions: `$HGVS = HGVS::check($sVariant)->requireVariant()`.
- Don't cache the info array anymore, simplify its use. Also fix many `getInfo()` calls that should have been `getData()`.
- Add `hasMessage()` and reduce direct interaction with `$messages`. Replace `isset()` calls for a certain message with `hasMessage()` and use `getMessages()` more often for interaction with `$messages`.
- Add `getMessagesByGroup()`, which replaces `buildInfo()`.
- Improve `getMessagesByGroup()`, reducing code complexity. We can now simply fetch all errors, warnings, or messages separately.
- Update `getInfo()` to return all relevant information in one array.