### PR TITLE
Add a README.

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -548,6 +548,8 @@ class HGVS
         $sReturn = $this->getMatchedPattern();
         if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
             $sReturn .= '_' . $this->Variant->getMatchedPattern();
+        } elseif ($sReturn == 'variant_identifier' && $this->hasProperty('VariantIdentifier')) {
+            $sReturn .= '_' . $this->VariantIdentifier->getMatchedPattern();
         }
         return $sReturn;
     }
@@ -563,6 +565,8 @@ class HGVS
         $sReturn = $this->getMatchedPatternFormatted();
         if (str_ends_with($sReturn, 'variant') && $this->hasProperty('Variant')) {
             $sReturn .= ' (' . str_replace('_', ', ', $this->Variant->getMatchedPattern()) . ')';
+        } elseif ($sReturn == 'variant identifier' && $this->hasProperty('VariantIdentifier')) {
+            $sReturn .= ' (' . str_replace('_', ', ', $this->VariantIdentifier->getMatchedPattern()) . ')';
         }
         return $sReturn;
     }
@@ -4772,22 +4776,12 @@ class HGVS_VariantIdentifier extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        $this->data = [
-            'position_start' => 0,
-            'position_end'   => 0,
-            'range'          => false,
-            'type'           => 'identifier',
-        ];
-        // Increase the confidence when we have no suffix, to counteract the EINVALID.
-        $nConfidence = ($this->suffix === ''? 10 : 1);
         if (substr($this->matched_pattern, 0, 7) == 'ClinVar') {
-            $this->setCorrectedValue(strtoupper($this->value), $nConfidence);
+            $this->setCorrectedValue(strtoupper($this->value));
         } else {
-            $this->setCorrectedValue(strtolower($this->value), $nConfidence);
+            $this->setCorrectedValue(strtolower($this->value));
         }
         $this->caseOK = ($this->value == $this->getCorrectedValue());
-        $this->messages['EINVALID'] = 'This is not a valid HGVS description; it looks like a ' .
-            str_replace('_', ' ', $this->matched_pattern) . ' identifier. Please provide a variant description following the HGVS nomenclature.';
     }
 }
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-02-13   // When modified, also change the library_version.
+ * Modified    : 2025-02-14   // When modified, also change the library_version.
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -459,6 +459,16 @@ class HGVS
 
 
 
+    public static function debug ($sInput)
+    {
+        // Creates a new instance of this class, checking the input, and turning on debugging.
+        return new static($sInput, null, true);
+    }
+
+
+
+
+
     public function discardSuffix ()
     {
         // This function discards the suffix. This is used in text parsing, when
@@ -750,7 +760,7 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_version' => '2025-02-13',
+            'library_version' => '2025-02-14',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',

--- a/HGVS.php
+++ b/HGVS.php
@@ -5221,3 +5221,22 @@ trait HGVS_DNASequence
         return $this->sequences;
     }
 }
+
+
+
+
+
+// Detect if we're called directly.
+if (!empty($_SERVER['argc']) && __FILE__ == realpath(getcwd() . '/' . $_SERVER['argv'][0])) {
+    // We're called directly.
+    array_shift($_SERVER['argv']);
+    $_SERVER['argc'] --;
+    if ($_SERVER['argc'] > 0) {
+        $aData = [];
+        foreach ($_SERVER['argv'] as $sVariant) {
+            $aData[] = HGVS::check($sVariant)->getInfo();
+        }
+        echo json_encode($aData, JSON_PRETTY_PRINT);
+        exit;
+    }
+}

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-02-12   // When modified, also change the library_version.
+ * Modified    : 2025-02-13   // When modified, also change the library_version.
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -737,7 +737,7 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_version' => '2025-02-12',
+            'library_version' => '2025-02-13',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',
@@ -5234,7 +5234,14 @@ if (!empty($_SERVER['argc']) && __FILE__ == realpath(getcwd() . '/' . $_SERVER['
     if ($_SERVER['argc'] > 0) {
         $aData = [];
         foreach ($_SERVER['argv'] as $sVariant) {
-            $aData[] = HGVS::check($sVariant)->getInfo();
+            if (in_array(strtolower($sVariant), ['version', 'versions', 'getversions'])) {
+                // It's annoying that we can't do "php -f HGVS.php -v" because PHP will take the "-v".
+                // Same with anything with two hyphens, like "--versions".
+                // "php -f HGVS.php -- --versions" could work, but maybe that's a bit much.
+                $aData[] = HGVS::getVersions();
+            } else {
+                $aData[] = HGVS::check($sVariant)->getInfo();
+            }
         }
         echo json_encode($aData, JSON_PRETTY_PRINT);
         exit;

--- a/HGVS.php
+++ b/HGVS.php
@@ -450,6 +450,15 @@ class HGVS
 
 
 
+    public static function checkVariant ($sInput)
+    {
+        return static::check($sInput)->requireVariant();
+    }
+
+
+
+
+
     public function discardSuffix ()
     {
         // This function discards the suffix. This is used in text parsing, when

--- a/README.md
+++ b/README.md
@@ -293,4 +293,13 @@ var_dump($HGVS->Variant->DNAVariantBody->DNAPositions->intronic); // False.
 // 2) Get an array of HGVS_DNAInsSuffixComplexComponent objects for a complex insertion:
 $aComponents = HGVS::check("c.419_420ins[T;450_470;AGGG]")->Variant->DNAVariantBody
                ->DNAVariantType->DNAInsSuffix->DNAInsSuffixComplex->getComponents();
+
+
+
+// Useful for parsing text; could the given input be incomplete?
+// 1) False, because this reference sequence is complete.
+var_dump(HGVS_ReferenceSequence::check('NM_004006.3')->isPossiblyIncomplete());
+// 2) True, because now, we're not just checking for a reference sequence,
+//     and this could be just the start of a variant description.
+var_dump(HGVS::check('NM_004006.3')->isPossiblyIncomplete());
 ```

--- a/README.md
+++ b/README.md
@@ -46,3 +46,29 @@ It powers the [LOVD HGVS Variant Description Syntax Checker](https://LOVD.nl/HGV
    extracted from databases or publications.
 - Diagnostic & Clinical Genetics laboratories that need automated HGVS validation
    as part of variant interpretation workflows.
+
+
+
+
+
+## Getting Started
+### The online LOVD HGVS Variant Description Syntax Checker
+For low-volume requests and no requirement for downloads or programming,
+ feel free to use the online [LOVD HGVS Variant Description Syntax Checker](https://LOVD.nl/HGVS).
+The interface should be self-explanatory.
+Use the "Check a list of variants" button to check a list of variants.
+The interface allows you to create a download of your results, too;
+ use the "Download this result" for a tab-delimited file.
+
+The online interface only considers variant descriptions as valid and allows reference sequences to be missing.
+For pro users, this means that `requireVariant()` and `allowMissingReferenceSequence()` are activated.
+
+
+
+### The API
+For direct programmatic access to the basic features, use the [free API](https://api.lovd.nl/).
+No registration is needed, but to keep the service available to all,
+ please keep the number of requests at a maximum of five variants per second, or one batch request per second.
+
+The API only considers variant descriptions as valid and allows reference sequences to be missing.
+For pro users, this means that `requireVariant()` and `allowMissingReferenceSequence()` are activated.

--- a/README.md
+++ b/README.md
@@ -206,3 +206,46 @@ var_dump($HGVS->isValid()); // False, because a reference sequence is required a
 // No longer consider not having a reference sequence as invalid.
 $HGVS->allowMissingReferenceSequence();
 var_dump($HGVS->isValid()); // Now, it returns True.
+
+// Return all information from the library about the given input.
+var_dump($HGVS->getInfo());
+// [
+//     "input" => "c.157C>T",
+//     "identified_as" => "variant_DNA",
+//     "identified_as_formatted" => "variant (DNA)",
+//     "valid" => true,
+//     "messages" => [
+//         "IREFSEQMISSING" => "This variant is missing a reference sequence."
+//     ],
+//     "warnings" => [],
+//     "errors" => [],
+//     "data" => [
+//         "position_start" => 157,
+//         "position_end" => 157,
+//         "position_start_intron" => 0,
+//         "position_end_intron" => 0,
+//         "range" => false,
+//         "type" => ">"
+//     ],
+//     "corrected_values" => [
+//         "c.157C>T" => 1
+//     ]
+// ]
+
+// If you want to have a subset of the above, the method getInfo() is internally defined as:
+// return array_merge(
+//     [
+//         'input' => $this->getInput(),
+//         'identified_as' => $this->getIdentifiedAs(),
+//         'identified_as_formatted' => $this->getIdentifiedAsFormatted(),
+//         'valid' => $this->isValid(),
+//     ],
+//     $this->getMessagesByGroup(),
+//     [
+//         'data' => $this->getData(),
+//         'corrected_values' => $this->getCorrectedValues(),
+//     ]
+// );
+
+// The above can again be combined like so:
+var_dump(HGVS::checkVariant('c.157C>T')->allowMissingReferenceSequence()->getInfo());

--- a/README.md
+++ b/README.md
@@ -190,3 +190,4 @@ var_dump(HGVS::checkVariant('NM_004006.3')->isValid()); // False.
 // If you're not interested in variants, you can also directly use other classes, like so:
 var_dump(HGVS_ReferenceSequence::check('NM_004006.3')->isValid()); // True.
 var_dump(HGVS_Genome::check('GRCh38')->isValid()); // True. We recognize hg18, hg19, hg38, GRCh36, GRCh37, and GRCh38.
+var_dump(HGVS_VariantIdentifier::check('rs123456')->isValid()); // True. Note that, also this, is just a syntax check.

--- a/README.md
+++ b/README.md
@@ -283,4 +283,14 @@ var_dump($HGVS->Variant->getProperties());
 //     "Dot",
 //     "DNAVariantBody"
 // ]
+
+
+
+// We haven't documented each class in detail, so feel free to use var_dump()
+//  to explore an object's structure. Two examples of the possibilities:
+// 1) Is a variant intronic?
+var_dump($HGVS->Variant->DNAVariantBody->DNAPositions->intronic); // False.
+// 2) Get an array of HGVS_DNAInsSuffixComplexComponent objects for a complex insertion:
+$aComponents = HGVS::check("c.419_420ins[T;450_470;AGGG]")->Variant->DNAVariantBody
+               ->DNAVariantType->DNAInsSuffix->DNAInsSuffixComplex->getComponents();
 ```

--- a/README.md
+++ b/README.md
@@ -262,3 +262,25 @@ $HGVS->requireMissingReferenceSequence();
 var_dump(HGVS::checkVariant('c.157C>T')->requireMissingReferenceSequence()->isValid()); // True.
 var_dump(HGVS::checkVariant('NM_004006.3:c.157C>T')->isValid()); // True.
 var_dump(HGVS::checkVariant('NM_004006.3:c.157C>T')->requireMissingReferenceSequence()->isValid()); // False.
+```
+
+The LOVD HGVS library offers much, much more.
+Check the source code for a full list of all useful methods and variables within classes.
+A few more have been highlighted below.
+
+```php
+// Get properties of this object, to get more information about how a variant was parsed.
+$HGVS = HGVS::checkVariant('c.157C>T');
+var_dump($HGVS->getProperties());
+// [
+//     "Variant"
+// ]
+
+// Using the property names, you can dive deeply into the parsed variant.
+var_dump($HGVS->Variant->getProperties());
+// [
+//     "DNAPrefix",
+//     "Dot",
+//     "DNAVariantBody"
+// ]
+```

--- a/README.md
+++ b/README.md
@@ -191,3 +191,18 @@ var_dump(HGVS::checkVariant('NM_004006.3')->isValid()); // False.
 var_dump(HGVS_ReferenceSequence::check('NM_004006.3')->isValid()); // True.
 var_dump(HGVS_Genome::check('GRCh38')->isValid()); // True. We recognize hg18, hg19, hg38, GRCh36, GRCh37, and GRCh38.
 var_dump(HGVS_VariantIdentifier::check('rs123456')->isValid()); // True. Note that, also this, is just a syntax check.
+
+
+
+// Now, try a variant description without a reference sequence.
+$HGVS = HGVS::checkVariant('c.157C>T');
+
+// Returns True if the library matched something (still, not necessarily a variant).
+var_dump($HGVS->hasMatched()); // True.
+
+// Returns True if the library matched a variant and considers the input as valid.
+var_dump($HGVS->isValid()); // False, because a reference sequence is required according to the HGVS nomenclature.
+
+// No longer consider not having a reference sequence as invalid.
+$HGVS->allowMissingReferenceSequence();
+var_dump($HGVS->isValid()); // Now, it returns True.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# LOVD HGVS Library & Variant Description Syntax Checker
+The LOVD HGVS library is a standalone, sequence-agnostic validation library for HGVS-compliant variant descriptions,
+ designed to detect and correct syntax errors, formatting issues, and common user mistakes.
+It powers the [LOVD HGVS Variant Description Syntax Checker](https://LOVD.nl/HGVS), a tool capable of validating,
+ correcting, and standardizing variant descriptions even without a reference sequence.
+
+
+
+
+
+## Main features
+- **Comprehensive HGVS Syntax Validation.**
+  Recognizes valid variant descriptions and detects syntax errors according to HGVS nomenclature guidelines.
+  The LOVD HGVS library supports more of the HGVS nomenclature than any other validation tool,
+   and has been trained to understand all kinds of invalid input.
+  Unlike sequence-level validation tools, using reference sequences is not necessary with the LOVD HGVS library.
+  However, if a reference sequence is available, after the variant description syntax has been validated, a tool like
+   [Mutalyzer](https://mutalyzer.nl) or [VariantValidator](https://variantvalidator.org) is required for full validation
+   of the variant on sequence level.
+- **Automated corrections with confidence scores.**
+  Provides suggested corrections for invalid descriptions, ranked by likelihood.
+  When multiple interpretations are possible, the library will provide multiple possible corrections.
+- **Supports multiple variant formats.**
+  Accepts legacy variant descriptions, VCF and similar formats such as SPDI,
+   and converts them into HGVS-compliant syntax.
+- **Handles formatting issues.**
+  Detects and corrects misformatted characters (e.g., en- and em-dashes where hyphens are needed) and spacing issues,
+   commonly introduced by the formatting of variant descriptions in PDFs.
+- **Lightweight & easy to integrate.**
+  Can be used as a PHP library or as a standalone command-line tool,
+   making it easy to integrate into existing pipelines, databases, or web applications.
+- **API and online interface available for low-volume requests.**
+  An [API](https://api.lovd.nl/) and the [LOVD HGVS Variant Description Syntax Checker](https://LOVD.nl/HGVS)
+   are available for low-volume requests and small batch requests.
+  The online Syntax Checker also allows for sequence-level validation of DNA or RNA variants
+   with the [VariantValidator](https://variantvalidator.org) software.
+
+
+
+
+
+## Who should use this?
+- Developers working on genomic variant databases, analysis pipelines,
+   or reporting tools that require HGVS-compliant variant descriptions.
+- Bioinformaticians & Researchers looking for a reliable tool to validate and correct variant descriptions
+   extracted from databases or publications.
+- Diagnostic & Clinical Genetics laboratories that need automated HGVS validation
+   as part of variant interpretation workflows.

--- a/README.md
+++ b/README.md
@@ -184,3 +184,5 @@ var_dump($HGVS->isValid()); // Now, it returns False.
 
 // This can be combined like:
 var_dump(HGVS::check('NM_004006.3')->requireVariant()->isValid()); // False.
+// Or, shorter:
+var_dump(HGVS::checkVariant('NM_004006.3')->isValid()); // False.

--- a/README.md
+++ b/README.md
@@ -302,4 +302,11 @@ var_dump(HGVS_ReferenceSequence::check('NM_004006.3')->isPossiblyIncomplete());
 // 2) True, because now, we're not just checking for a reference sequence,
 //     and this could be just the start of a variant description.
 var_dump(HGVS::check('NM_004006.3')->isPossiblyIncomplete());
+
+
+
+// With debugging mode, the class will output a large amount of text with
+//  which you can follow the logic used to match your input.
+// Turn on output buffering if you wish to collect this output into a variable.
+$HGVS = HGVS::debug('c.157C>T');
 ```

--- a/README.md
+++ b/README.md
@@ -72,3 +72,51 @@ No registration is needed, but to keep the service available to all,
 
 The API only considers variant descriptions as valid and allows reference sequences to be missing.
 For pro users, this means that `requireVariant()` and `allowMissingReferenceSequence()` are activated.
+
+
+
+### The LOVD HGVS library
+#### As a standalone tool run directly on the system (e.g., from Bash or Python).
+If you have PHP-cli installed, you can run the library directly from the command-line:
+
+```bash
+php -f HGVS.php "NM_004006.3:c.157C>T"
+```
+
+The output is basically the same as the API's output, minus the API wrapper:
+
+```json
+[
+  {
+    "input": "NM_004006.3:c.157C>T",
+    "identified_as": "full_variant_DNA",
+    "identified_as_formatted": "full variant (DNA)",
+    "valid": true,
+    "messages": [],
+    "warnings": [],
+    "errors": [],
+    "data": {
+      "position_start": 157,
+      "position_end": 157,
+      "position_start_intron": 0,
+      "position_end_intron": 0,
+      "range": false,
+      "type": ">"
+    },
+    "corrected_values": {
+      "NM_004006.3:c.157C>T": 1
+    }
+  }
+]
+```
+
+Multiple input values can be passed:
+
+```bash
+php -f HGVS.php "NM_004006.3:c.157C>T" "NC_000015.9:g.40699840C>T"
+```
+
+Note that, unlike the API, the defaults apply.
+The HGVS class will also successfully validate reference sequences,
+ VCF descriptions, genome builds, and variant identifiers.
+If you only wish to consider variants as valid input, check the `identified_as` field, or use a PHP wrapper (see below).

--- a/README.md
+++ b/README.md
@@ -144,3 +144,43 @@ Note that, unlike the API, the defaults apply.
 The HGVS class will also successfully validate reference sequences,
  VCF descriptions, genome builds, and variant identifiers.
 If you only wish to consider variants as valid input, check the `identified_as` field, or use a PHP wrapper (see below).
+
+#### From within a PHP application
+When already coding in PHP, it's easy to just include the `HGVS.php` library file and start using it.
+Using this method, you'll have full access to all features the library can offer.
+
+```php
+<?php
+// Include the HGVS.php file.
+require 'path/to/HGVS.php';
+
+// Check all version info.
+$aVersions = HGVS::getVersions();
+// [
+//     "library_version" => "2025-02-13",
+//     "HGVS_nomenclature_versions" => [
+//         "input" => [
+//             "minimum" => "15.11",
+//             "maximum" => "21.1.1"
+//         ],
+//         "output" => "21.1.1"
+//     ]
+// ]
+
+// Check some input. Note that, by default, the LOVD HGVS library searches for variants
+//  (with or without reference sequences), reference sequences, VCF strings, genome builds, and variant identifiers.
+// Use the default HGVS class for all options. 
+$HGVS = HGVS::check('NM_004006.3'); // Returns an object.
+
+// Returns True if the library matched something (not necessarily a variant).
+var_dump($HGVS->hasMatched()); // True.
+
+// Returns True if the library matched something and considers the input as valid.
+var_dump($HGVS->isValid()); // True, because this is a valid reference sequence.
+
+// Make sure that we only consider variant input as valid.
+$HGVS->requireVariant();
+var_dump($HGVS->isValid()); // Now, it returns False.
+
+// This can be combined like:
+var_dump(HGVS::check('NM_004006.3')->requireVariant()->isValid()); // False.

--- a/README.md
+++ b/README.md
@@ -249,3 +249,13 @@ var_dump($HGVS->getInfo());
 
 // The above can again be combined like so:
 var_dump(HGVS::checkVariant('c.157C>T')->allowMissingReferenceSequence()->getInfo());
+
+
+
+// Meant for databases, where sometimes filling in a reference sequence is not allowed.
+$HGVS->requireMissingReferenceSequence();
+
+// Can be combined like so:
+var_dump(HGVS::checkVariant('c.157C>T')->requireMissingReferenceSequence()->isValid()); // True.
+var_dump(HGVS::checkVariant('NM_004006.3:c.157C>T')->isValid()); // True.
+var_dump(HGVS::checkVariant('NM_004006.3:c.157C>T')->requireMissingReferenceSequence()->isValid()); // False.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ For pro users, this means that `requireVariant()` and `allowMissingReferenceSequ
 
 ### The API
 For direct programmatic access to the basic features, use the [free API](https://api.lovd.nl/).
+The LOVD API includes the LOVD HGVS library starting from version 2.
+To access the LOVD HGVS library, use the "checkHGVS" API endpoint.
+When using the API web interface, make sure "v2 (2025-02-19)" is selected in the top bar of the page.
+When calling the API directly, use "v2" in the URL.
+See our full [API documentation](https://github.com/LOVDnl/api.lovd.nl/) for how to use the API.
+
 No registration is needed, but to keep the service available to all,
  please keep the number of requests at a maximum of five variants per second, or one batch request per second.
 

--- a/README.md
+++ b/README.md
@@ -186,3 +186,7 @@ var_dump($HGVS->isValid()); // Now, it returns False.
 var_dump(HGVS::check('NM_004006.3')->requireVariant()->isValid()); // False.
 // Or, shorter:
 var_dump(HGVS::checkVariant('NM_004006.3')->isValid()); // False.
+
+// If you're not interested in variants, you can also directly use other classes, like so:
+var_dump(HGVS_ReferenceSequence::check('NM_004006.3')->isValid()); // True.
+var_dump(HGVS_Genome::check('GRCh38')->isValid()); // True. We recognize hg18, hg19, hg38, GRCh36, GRCh37, and GRCh38.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@ var_dump($HGVS->hasMatched()); // True.
 // Returns True if the library matched something and considers the input as valid.
 var_dump($HGVS->isValid()); // True, because this is a valid reference sequence.
 
-// Make sure that we only consider variant input as valid.
+// To quickly check if something is a variant description (not necessarily a valid description), use:
+var_dump($HGVS->isAVariant()); // False.
+
+// As an alternative, make sure that we only consider variant input as valid:
 $HGVS->requireVariant();
 var_dump($HGVS->isValid()); // Now, it returns False.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ Multiple input values can be passed:
 php -f HGVS.php "NM_004006.3:c.157C>T" "NC_000015.9:g.40699840C>T"
 ```
 
+To retrieve information about the library, pass `versions` or `getVersions`, like:
+
+```bash
+php -f HGVS.php versions
+php -f HGVS.php getVersions
+```
+
+This returns:
+
+```json
+[
+    {
+        "library_version": "2025-02-12",
+        "HGVS_nomenclature_versions": {
+            "input": {
+                "minimum": "15.11",
+                "maximum": "21.1.1"
+            },
+            "output": "21.1.1"
+        }
+    }
+]
+```
+
 Note that, unlike the API, the defaults apply.
 The HGVS class will also successfully validate reference sequences,
  VCF descriptions, genome builds, and variant identifiers.


### PR DESCRIPTION
### Add a README and a CLI interface.
- Add the basics of the README.
- Add the basic information about the online interfaces.
- Add the command-line interface (CLI). This makes the library truly standalone; not even a PHP wrapper is needed to use it.
- Document the CLI.
- Add option to fetch the library versions through the CLI. Also, document this.
- Start the documentation for PHP libraries.
- Add `checkVariant()`, using `requireVariant()`, allowing for shorter syntax.
- Clarify that direct classes can be used, too.
- Make sure variant identifiers can also be validated. Currently, they are always considered invalid, but that doesn't match with how we handle other objects like reference sequences or genome builds. Also, adapt `getIdentifiedAs()` to make sure we nicely identify the type of variant identifier.
- Explain `allowMissingReferenceSequence()` and document its use.
- Document the `getInfo()` output and how its built.
- Document the use of `requireMissingReferenceSequence()`.
- Document `isAVariant()` as a useful alternative to `requireVariant()`.
- Document `getProperties()`.
- Give some examples of how to interact with the objects more.
- Document `isPossiblyIncomplete()`.
- Add `HGVS::debug()` and document it.
- Now that the API is updated, add that info to the manual.
