### PR TITLE
Add the ANNOVAR format.

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -520,8 +520,14 @@ class HGVS
             }
         }
 
-        // If we end up here, we have built something.
-        $this->corrected_values = $aCorrectedValues;
+        // If we end up here, we have built something. Round the values to prevent crazy floats.
+        $this->corrected_values = array_map(
+            function ($nVal)
+            {
+                return round($nVal, 5);
+            },
+            $aCorrectedValues
+        );
         return $this->corrected_values;
     }
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-03-18   // When modified, also change the library_version.
+ * Modified    : 2025-03-19   // When modified, also change the library_version.
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -745,13 +745,13 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_version' => '2025-03-17',
+            'library_version' => '2025-03-19',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',
-                    'maximum' => '21.1.1',
+                    'maximum' => '21.1.2',
                 ],
-                'output' => '21.1.1',
+                'output' => '21.1.2',
             ],
         ];
     }

--- a/HGVS.php
+++ b/HGVS.php
@@ -47,6 +47,7 @@ class HGVS
 
     public function __construct ($sValue, $Parent = null, $bDebugging = false)
     {
+        $sValue = str_replace(' ', ' ', $sValue); // Replace "thin spaces" by spaces, which are trim()able.
         $this->input = $sValue;
         $this->parent = $Parent;
         $this->debugging = $bDebugging;

--- a/HGVS.php
+++ b/HGVS.php
@@ -4387,7 +4387,7 @@ class HGVS_ReferenceSequence extends HGVS
         // NOTE: The HGVS_Chromosome class also handles the chr(build) syntax.
         'chr'                         => ['HGVS_Chromosome', []],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
-        'other'                       => ['/([^:;\[\]]{2,})?(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.']],
+        'other'                       => ['/([A-Z][^:;\[\]\(\)]{2,})?(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.']],
     ];
 
     public function validate ()

--- a/HGVS.php
+++ b/HGVS.php
@@ -936,6 +936,17 @@ class HGVS
 
 
 
+class HGVS_ANNOVARExon extends HGVS
+{
+    public array $patterns = [
+        ['/exon[0-9]+/', []],
+    ];
+}
+
+
+
+
+
 class HGVS_Caret extends HGVS
 {
     public array $patterns = [
@@ -4060,6 +4071,18 @@ class HGVS_Dot extends HGVS
             }
         }
     }
+}
+
+
+
+
+
+class HGVS_Gene extends HGVS
+{
+    // NOTE: This will be extended later on. For now, we just need a pattern to match gene symbols.
+    public array $patterns = [
+        ['/([A-Z][A-Za-z0-9#@-]*)/', []],
+    ];
 }
 
 

--- a/web/ajax.php
+++ b/web/ajax.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2025-03-14
+ * Modified    : 2025-03-19
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -120,6 +120,9 @@ foreach ($aVariants as $sVariant) {
 
         } elseif (!$aVariant['valid']) {
             $aVariant['VV']['EFAIL'] = 'Please first correct the variant description to run VariantValidator.';
+
+        } elseif (!in_array($aVariant['identified_as'], ['full_variant_DNA', 'full_variant_RNA', 'variant_DNA', 'variant_RNA'])) {
+            $aVariant['VV']['WNOTSUPPORTED'] = 'VariantValidator currently supports DNA and RNA variants as input.';
 
         } elseif (isset($aVariant['messages']['IREFSEQMISSING'])) {
             $aVariant['VV']['EREFSEQMISSING'] = 'Please provide a reference sequence to run VariantValidator.';


### PR DESCRIPTION
### Add the ANNOVAR format.
- Recognize and handle a range of ANNOVAR output formats. Examples:
  - `NPHP4(NM_001291593:exon19:c.1279-2T>A,NM_001291594:exon18:c.1282-2T>A,NM_015102:exon22:c.2818-2T>A)`
  - `APC:NM_001127510:exon17:c.G4057T:p.E1353X`
  - `NM_000186:exon1:c.5G > C`
- Handle "thin spaces", which aren't recognized as spaces. They don't respond to `trim()`, nor do they match `\s` in a regex. So, we'll replace them with a normal space. We found this "thin space" in an ANNOVAR example in a paper (last example given above).
- Be even stricter with "other" reference sequences. This specific pattern is a nightmare; it generates false positives all the time. So I made it even stricter so it would stop matching some of the ANNOVAR notations.


### Also:
- Update the HGVS nomenclature versions; there has been a new release.
- Round the floats in the corrected values.
- Make sure that valid protein descriptions aren't sent to VV.
