### PR TITLE
Add gene validation

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -4341,6 +4341,12 @@ class HGVS_Gene extends HGVS
                     $this->setCorrectedValue($sSymbol);
                 }
             }
+
+        } else {
+            // Just warn the user that we can't validate gene symbols at the moment.
+            $this->messages['INOSYMBOLVALIDATION'] = 'We currently can not validate gene symbols because the gene list has not been downloaded. See the documentation on how to download the gene symbol list.';
+            // Lower the confidence.
+            $this->corrected_values = $this->buildCorrectedValues([$this->value => 0.5]);
         }
         parent::validate(); // Do a case-check.
     }

--- a/HGVS.php
+++ b/HGVS.php
@@ -4283,10 +4283,30 @@ class HGVS_Dot extends HGVS
 
 class HGVS_Gene extends HGVS
 {
-    // NOTE: This will be extended later on. For now, we just need a pattern to match gene symbols.
     public array $patterns = [
         ['/([A-Z][A-Za-z0-9#@-]*)/', []],
     ];
+    public static array $genes = [];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        // If the gene data is present, we can validate a gene symbol properly.
+        if (empty(self::$genes)) {
+            // We haven't loaded the file yet, find and load it.
+            $sFile = dirname(__FILE__) . '/cache/genes.json';
+            if (is_readable($sFile)) {
+                $sJSON = @file_get_contents($sFile);
+                if ($sJSON) {
+                    $aJSON = @json_decode($sJSON, true);
+                    if ($aJSON !== false && array_keys($aJSON) == ['genes', 'IDs']) {
+                        self::$genes = $aJSON;
+                    }
+                }
+            }
+        }
+        parent::validate(); // Do a case-check.
+    }
 }
 
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -924,7 +924,12 @@ class HGVS
         if (!$this->parent) {
             // Top-level validation.
             if (!$this->caseOK) {
-                $this->messages['WWRONGCASE'] = 'This is not a valid HGVS description, due to characters being in the wrong case.';
+                if ($this->isAVariant()) {
+                    $sObject = 'HGVS description';
+                } else {
+                    $sObject = $this->getIdentifiedAsFormatted();
+                }
+                $this->messages['WWRONGCASE'] = 'This is not a valid ' . $sObject . ', due to characters being in the wrong case.';
             }
 
             if (get_class($this) == 'HGVS') {
@@ -4865,6 +4870,7 @@ class HGVS_ReferenceSequence extends HGVS
                 }
                 break;
         }
+        parent::validate(); // Do a case-check.
     }
 }
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-04-24   // When modified, also change the library_version.
+ * Modified    : 2025-04-28   // When modified, also change the library_version.
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -753,8 +753,8 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_date' => '2025-04-24',
-            'library_version' => '0.4.3',
+            'library_date' => '2025-04-28',
+            'library_version' => '0.4.4',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',

--- a/HGVS.php
+++ b/HGVS.php
@@ -1362,6 +1362,7 @@ class HGVS_DNAAlts extends HGVS
                 $this->setCorrectedValue(str_replace('U', 'T', $this->getCorrectedValue()));
             }
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -1472,6 +1473,7 @@ class HGVS_DNADel extends HGVS
         $this->setCorrectedValue(strtolower($this->value));
         $this->data['type'] = $this->getCorrectedValue();
         $this->caseOK = ($this->value == $this->getCorrectedValue());
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -1724,6 +1726,7 @@ class HGVS_DNAIns extends HGVS
                 $Positions->makeCertain();
             }
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -2047,6 +2050,7 @@ class HGVS_DNAInv extends HGVS
                 ' Please remove the parentheses if the positions are certain.';
             $Positions->makeCertain();
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -2189,6 +2193,7 @@ class HGVS_DNAPipeSuffix extends HGVS
                 $this->messages['WMETFORMAT'] = 'To report normal methylation, use "met=".';
             }
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -2324,6 +2329,7 @@ class HGVS_DNAPosition extends HGVS
                 $this->position_limits[3] = $this->offset;
             }
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -3256,6 +3262,7 @@ class HGVS_DNAPrefix extends HGVS
             unset($this->messages['WPREFIXFORMAT']); // Remove the warning in case HGVS_Dot is missing, too.
             $this->messages['EPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $this->getCorrectedValue() . '.").';
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -3294,6 +3301,7 @@ class HGVS_DNARefs extends HGVS
                 $this->setCorrectedValue(str_replace('U', 'T', $this->getCorrectedValue()));
             }
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -3629,6 +3637,7 @@ class HGVS_DNASup extends HGVS
             $this->messages['EWRONGREFERENCE'] =
                 'A chromosomal reference sequence is required to report supernumerary chromosomes.';
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -4233,6 +4242,7 @@ class HGVS_DNAVariantType extends HGVS
                 $this->possibly_incomplete = true;
             }
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -4917,6 +4927,7 @@ class HGVS_RNAPrefix extends HGVS
                 'The given reference sequence (' . $RefSeq->getCorrectedValue() . ') does not match the RNA type (' . $this->getCorrectedValue() . ').' .
                 ' For ' . $this->getCorrectedValue() . '. variants, please use a ' . $this->molecule_type . ' reference sequence.';
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -5043,6 +5054,7 @@ class HGVS_ProteinPrefix extends HGVS
                 'The given reference sequence (' . $RefSeq->getCorrectedValue() . ') does not match the protein type (' . $this->getCorrectedValue() . ').' .
                 ' For ' . $this->getCorrectedValue() . '. variants, please use a ' . $this->molecule_type . ' reference sequence.';
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -5093,6 +5105,7 @@ class HGVS_ProteinRef extends HGVS
                 $this->messages['EINVALIDAMINOACIDS'] = 'This variant description contains invalid amino acids: "' . $this->value . '".';
             }
         }
+        parent::validate(); // Do a case-check.
     }
 }
 
@@ -5155,6 +5168,7 @@ class HGVS_VariantIdentifier extends HGVS
             $this->setCorrectedValue(strtolower($this->value));
         }
         $this->caseOK = ($this->value == $this->getCorrectedValue());
+        parent::validate(); // Do a case-check.
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -318,3 +318,23 @@ var_dump(HGVS::check('NM_004006.3')->isPossiblyIncomplete());
 // Turn on output buffering if you wish to collect this output into a variable.
 $HGVS = HGVS::debug('c.157C>T');
 ```
+
+
+
+
+
+## Features that require configuration
+### Gene symbol recognition
+The LOVD HGVS library contains a feature that recognizes and corrects gene symbols.
+In order for this to work, the library relies on a local copy of the official gene symbol list
+ from the HUGO Gene Nomenclature Committee (HGNC).
+To obtain this copy, an update script needs to be run on a regular basis; for instance, once a month.
+The update script is located in the `cache` directory.
+You can invoke it like:
+
+```bash
+php -f cache/update.php
+```
+
+This can be automated by using, for instance, cron jobs.
+Make sure that the user who runs the script has write access to the `cache` directory.

--- a/cache/update.php
+++ b/cache/update.php
@@ -1,0 +1,84 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2025-04-16
+ * Modified    : 2025-04-24
+ *
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *************/
+
+if (isset($_SERVER['HTTP_HOST'])) {
+    // We're being run through a browser.
+    mb_internal_encoding('UTF-8');
+    header('Content-type: text/plain; charset=UTF-8');
+}
+
+
+
+
+
+// 1) Check if we can write here at all.
+chdir(dirname(__FILE__));
+if (!is_writable('./')) {
+    echo "The cache dir is not writable.\n";
+    exit(1);
+}
+
+
+
+
+
+// 2) Update the gene cache, if needed.
+$sCacheFile = 'genes.json';
+$sSource = 'https://lovd.nl/mirrors/hgnc/symbol_to_ID.txt';
+$bUpdateCache = (!file_exists($sCacheFile) || filemtime($sCacheFile) < strtotime('-6 days'));
+
+if (!$bUpdateCache) {
+    echo "Gene cache not yet expired.\n";
+} else {
+    echo "Gene cache expired, attempting to refresh...\n";
+    $aData = file($sSource, FILE_IGNORE_NEW_LINES);
+    if (!$aData) {
+        echo "Could not load the remote data.\n";
+        exit(2);
+    }
+    $aCache = [
+        'genes' => [],
+        'IDs' => [],
+    ];
+    foreach ($aData as $sLine) {
+        // Explode the data into gene and HGNC ID.
+        list($sSymbol, $nID) = array_pad(explode("\t", $sLine), 2, 0);
+        $nID = (int) $nID;
+
+        // Also filter the data a bit.
+        if (!preg_match('/^[A-Z][A-Za-z0-9#@-]*$/', $sSymbol)) {
+            // This gene symbol doesn't look like a gene symbol. Ignore.
+        } else {
+            // What is left, store.
+            if (!isset($aCache['IDs'][$nID])) {
+                // This is the first time we've seen this HGNC ID. We will store the symbol as the official symbol.
+                $aCache['IDs'][$nID] = $sSymbol;
+            }
+
+            // Store the lowercase gene symbol with a reference to the HGNC ID.
+            $sSymbol = strtolower($sSymbol);
+            if (!isset($aCache['genes'][$sSymbol])) {
+                // This is the first time we've seen this symbol. We'll link this HGNC ID to it.
+                $aCache['genes'][$sSymbol] = $nID;
+            }
+        }
+    }
+
+    // Now store the file.
+    if (!file_put_contents($sCacheFile, json_encode($aCache))) {
+        echo "Could not save the gene data.\n";
+        exit(3);
+    } else {
+        echo 'Successfully stored ' . count($aCache['genes']) . ' symbols, ' . count($aCache['IDs']) . " unique genes.\n";
+    }
+}


### PR DESCRIPTION
### Add gene validation
- Add an update script that loads the gene cache.
- When validating a gene symbol, attempt to load the gene cache.
  - When we have the cache loaded, validate the gene symbol.
  - When we don't have the gene cache loaded, warn the user.
- Also support the HGNC:12345 format. I had to edit the `ReferenceSequence` object for this, to make sure that "HGNC" wasn't considered a reference sequence.
- Improve handling of case warnings.
  - Gene symbols not typed in the correct case would be reported as not being a valid HGVS description. Now, it reports it's not a valid gene. We could improve the wording even more, but it's easier to rely on `getIdentifiedAsFormatted()` due to all the subclasses. Also, run the case check in the ReferenceSequence object when it's called directly.
  - Add the case checks everywhere. This is only relevant when the classes are called directly. When called through the HGVS class, the main `validate()` method would already be run.
- Update the library version and the manual.