### PR TITLE
Fix VV's prediction method

### DIFF
--- a/variant_validator.php
+++ b/variant_validator.php
@@ -366,7 +366,7 @@ class LOVD_VV
             return false;
         }
 
-        if (!isset($aMapping['RNA'])) {
+        if (empty($aMapping['RNA'])) {
             $aMapping['RNA'] = 'r.(?)';
         }
         if (!isset($aMapping['protein'])) {
@@ -398,7 +398,6 @@ class LOVD_VV
                     $aMapping['protein'] = 'p.?';
 
                 } elseif ($aVariantInfo['position_start_intron'] && $aVariantInfo['position_end_intron']
-                    && abs($aVariantInfo['position_start_intron']) > 5 && abs($aVariantInfo['position_end_intron']) > 5
                     && ($aVariantInfo['position_start'] == $aVariantInfo['position_end']
                         || ($aVariantInfo['position_start'] + 1) == $aVariantInfo['position_end'])) {
                     // Deep intronic in the same intron.

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -410,8 +410,8 @@ class LOVD_VV
                     $aMapping['RNA'] = 'r.(?)';
                     $aMapping['protein'] = 'p.(=)';
 
-                } elseif ($aVariantInfo['position_start'] < 0 && strpos($aMapping['DNA'], '*') !== false) {
-                    // Start is upstream, end is downstream.
+                } elseif ($aVariantInfo['position_start'] < 0) {
+                    // Start is upstream, end is not.
                     if ($aVariantInfo['type'] == 'del') {
                         $aMapping['RNA'] = 'r.0?';
                         $aMapping['protein'] = 'p.0?';

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -439,7 +439,7 @@ class LOVD_VV
                 }
 
                 // But wait, did we just fill in a protein field for a non-coding transcript?
-                if (substr($sTranscript, 1, 1) == 'R') {
+                if (substr($sTranscript, 1, 1) == 'R' || substr($aMapping['DNA'], 0, 2) == 'n.') {
                     $aMapping['protein'] = '';
                 }
             }

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -431,8 +431,12 @@ class LOVD_VV
                     $aMapping['protein'] = 'p.?';
 
                 } else {
-                    // Substitution on wobble base or so.
+                    // Variants are fully in the CDS, or there is no CDS (non-coding transcripts).
+                    // If introns are involved, it's whole exon deletion or duplication and splicing is not expected to be affected.
                     $aMapping['RNA'] = 'r.(?)';
+                    if ($aMapping['protein'] != 'p.(=)') {
+                        $aMapping['protein'] = 'p.?';
+                    }
                 }
 
                 // But wait, did we just fill in a protein field for a non-coding transcript?

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2025-08-18
+ * Modified    : 2025-08-22
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -414,7 +414,7 @@ class LOVD_VV
 
                     } elseif ($aVariantInfo['position_start'] < 0 && strpos($aMapping['DNA'], '*') !== false) {
                         // Start is upstream, end is downstream.
-                        if ($aMapping['type'] == 'del') {
+                        if ($aVariantInfo['type'] == 'del') {
                             $aMapping['RNA'] = 'r.0?';
                             $aMapping['protein'] = 'p.0?';
                         } else {

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -425,8 +425,8 @@ class LOVD_VV
                     $aMapping['RNA'] = 'r.(?)';
                     $aMapping['protein'] = 'p.(=)';
 
-                } elseif ($aVariantInfo['type'] != '>' && $aMapping['protein'] != 'p.(=)') {
-                    // Non-SNVs partially in the transcript, not predicted to do nothing.
+                } elseif (strpos($aMapping['DNA'], '*') !== false && $aMapping['protein'] != 'p.(=)') {
+                    // Variant end is downstream of the CDS, start is not; not predicted to do nothing.
                     $aMapping['RNA'] = 'r.?';
                     $aMapping['protein'] = 'p.?';
 


### PR DESCRIPTION
### Fix VV's prediction method
- Fix warning for an unknown array key.
- Add a variant prefix check to the non-coding transcript check. This way, if no transcript has been passed to us, we can still know if this is a non-coding transcript.
- Simplify the code a bit. One big else full of if/elseifs/else is just a continuation of the previous if/elseifs.
- Add handling of TIS loss. It's really just the same as a whole-gene loss.
- Fix the check for variants half outside of the CDS.
- Improve documentation and fill in empty protein prediction.
- Final cleanup.