### PR TITLE
Add support for composer

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -4,12 +4,29 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2026-02-10   // When modified, also change the library_version.
+ * Modified    : 2026-02-12   // When modified, also change the library_version.
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *************/
+
+namespace LOVD\HGVS;
+
+function get_class ($o)
+{
+    // Overloading \get_class() that includes the current namespace, complicating my code everywhere.
+    $s = \get_class($o);
+    if (strpos($s, __NAMESPACE__ . '\\') === 0) {
+        // This class is in our own namespace.
+        return str_replace(__NAMESPACE__ . '\\', '', $s);
+    }
+    return $s;
+}
+
+
+
+
 
 #[AllowDynamicProperties]
 class HGVS
@@ -98,7 +115,8 @@ class HGVS
                             }
                             print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, result is pending.\n");
                         }
-                        $aPattern[$i] = new $sPattern($sInputToParse, $this, $bDebugging);
+                        $sFullName = __NAMESPACE__ . '\\' . $sPattern; // Required, otherwise PHP doesn't find the class.
+                        $aPattern[$i] = new $sFullName($sInputToParse, $this, $bDebugging);
                         // Store for later, if needed.
                         $this->memory[$sPattern][$sInputToParse] = $aPattern[$i];
                     }
@@ -783,8 +801,8 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_date' => '2026-02-10',
-            'library_version' => '0.6.0',
+            'library_date' => '2026-02-12',
+            'library_version' => '1.0.0',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ This returns:
 ```json
 [
     {
-        "library_date": "2026-02-10",
-        "library_version": "0.6.0",
+        "library_date": "2026-02-12",
+        "library_version": "1.0.0",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
@@ -192,18 +192,20 @@ E.g., when enforcing a gene check,
 
 #### From within a PHP application
 When already coding in PHP, it's easy to just include the `HGVS.php` library file and start using it.
-Using this method, you'll have full access to all features the library can offer.
+See further below for a method using `composer`, if you prefer that.
+When using the library directly in PHP, you'll have full access to all features the library can offer.
 
 ```php
 <?php
-// Include the HGVS.php file.
+// Include the HGVS.php file. Note that the class uses the LOVD\HGVS namespace.
 require 'path/to/HGVS.php';
+use LOVD\HGVS\HGVS;
 
 // Check all version info.
 $aVersions = HGVS::getVersions();
 // [
-//     "library_date" => "2026-02-10",
-//     "library_version" => "0.6.0",
+//     "library_date" => "2026-02-12",
+//     "library_version" => "1.0.0",
 //     "HGVS_nomenclature_versions" => [
 //         "input" => [
 //             "minimum" => "15.11",
@@ -241,9 +243,9 @@ var_dump(HGVS::check('NM_004006.3')->requireVariant()->isValid()); // False.
 var_dump(HGVS::checkVariant('NM_004006.3')->isValid()); // False.
 
 // If you're not interested in variants, you can also directly use other classes, like so:
-var_dump(HGVS_ReferenceSequence::check('NM_004006.3')->isValid()); // True.
-var_dump(HGVS_Genome::check('GRCh38')->isValid()); // True. We recognize hg18, hg19, hg38, GRCh36, GRCh37, and GRCh38.
-var_dump(HGVS_VariantIdentifier::check('rs123456')->isValid()); // True. Note that, also this, is just a syntax check.
+var_dump(LOVD\HGVS\HGVS_ReferenceSequence::check('NM_004006.3')->isValid()); // True.
+var_dump(LOVD\HGVS\HGVS_Genome::check('GRCh38')->isValid()); // True. We recognize hg18, hg19, hg38, GRCh36, GRCh37, and GRCh38.
+var_dump(LOVD\HGVS\HGVS_VariantIdentifier::check('rs123456')->isValid()); // True. Note that, also this, is just a syntax check.
 
 
 
@@ -348,7 +350,7 @@ $aComponents = HGVS::check("c.419_420ins[T;450_470;AGGG]")->Variant->DNAVariantB
 
 // Useful for parsing text; could the given input be incomplete?
 // 1) False, because this reference sequence is complete.
-var_dump(HGVS_ReferenceSequence::check('NM_004006.3')->isPossiblyIncomplete());
+var_dump(LOVD\HGVS\HGVS_ReferenceSequence::check('NM_004006.3')->isPossiblyIncomplete());
 // 2) True, because now, we're not just checking for a reference sequence,
 //     and this could be just the start of a variant description.
 var_dump(HGVS::check('NM_004006.3')->isPossiblyIncomplete());
@@ -359,6 +361,32 @@ var_dump(HGVS::check('NM_004006.3')->isPossiblyIncomplete());
 //  which you can follow the logic used to match your input.
 // Turn on output buffering if you wish to collect this output into a variable.
 $HGVS = HGVS::debug('c.157C>T');
+```
+
+#### Including the library into your project using composer
+Starting from v1.0.0, you can use `composer` to include the HGVS syntax checker.
+In your project's `composer.json`, add:
+
+```json
+"repositories": [
+    {
+        "type": "vcs",
+        "url": "https://github.com/LOVDnl/HGVS-syntax-checker"
+    }
+],
+```
+
+Then, require the HGVS syntax checker package:
+
+```bash
+composer require lovd/hgvs-syntax-checker
+```
+
+Then, from within your project, you can do, e.g.,:
+
+```php
+use LOVD\HGVS\HGVS;
+$HGVS = HGVS::checkVariant('c.157C>T');
 ```
 
 

--- a/caches.php
+++ b/caches.php
@@ -58,7 +58,7 @@ class caches
         }
         // Initiate VV if not already done so.
         if (!self::$oVV) {
-            self::$oVV = new LOVD_VV();
+            self::$oVV = new VV();
         }
 
         // Call VV with the defaults and collect all information.

--- a/caches.php
+++ b/caches.php
@@ -4,13 +4,14 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2025-06-06
- * Modified    : 2025-06-11
+ * Modified    : 2026-02-12
  *
- * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *************/
 
+namespace LOVD\HGVS;
 require_once 'HGVS.php';
 require_once 'variant_validator.php';
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "lovd/hgvs-syntax-checker",
+    "description": "PHP library to validate variant descriptions in the HGVS nomenclature syntax. Also includes a variant caching library and the VariantValidator interface.",
+    "type": "library",
+    "license": "GPL-3.0-only",
+    "authors": [
+        {
+            "name": "Ivo Fokkema",
+            "email": "I.F.A.C.Fokkema@LUMC.nl",
+            "role": "Developer"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "LOVD\\HGVS\\": ""
+        },
+        "classmap": ["caches.php", "HGVS.php", "variant_validator.php"]
+    },
+    "require": {}
+}

--- a/manuscript-2025/check-HGVS
+++ b/manuscript-2025/check-HGVS
@@ -1,7 +1,7 @@
 #!/bin/php
 <?php
 // Created  2024-12-30
-// Modified 2025-01-10
+// Modified 2026-02-12
 
 if (empty($_SERVER['argc']) || $_SERVER['argc'] != 2) {
     if (empty($_SERVER['argv'])) {
@@ -47,7 +47,7 @@ require '../HGVS.php';
 foreach ($aInput as $aLine) {
     $aOutput = $aLine;
     $sVariant = $aLine[0];
-    $HGVS = new HGVS($sVariant);
+    $HGVS = new LOVD\HGVS\HGVS($sVariant);
     $HGVS->allowMissingReferenceSequence(); // Don't freak out if there is no refseq.
     $aOutput[] = ($HGVS->isValid()? 'valid' : 'invalid');
     $aMessages = $HGVS->getMessages();

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -16,7 +16,7 @@ if (!class_exists('HGVS')) {
     require_once('HGVS.php');
 }
 
-class LOVD_VV
+class VV
 {
     // This class defines the LOVD VV object, handling all Variant Validator calls.
 

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -4,13 +4,14 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2025-08-22
+ * Modified    : 2026-02-12
  *
- * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *************/
 
+namespace LOVD\HGVS;
 if (!class_exists('HGVS')) {
     require_once('HGVS.php');
 }

--- a/web/ajax.php
+++ b/web/ajax.php
@@ -4,9 +4,9 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2025-03-19
+ * Modified    : 2026-02-12
  *
- * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *************/
@@ -39,7 +39,7 @@ if (empty($_REQUEST['var'])) {
 
 if (!empty($_REQUEST['callVV']) && $_REQUEST['callVV'] == 'true') {
     require '../variant_validator.php';
-    $_VV = new LOVD_VV();
+    $_VV = new LOVD\HGVS\LOVD_VV();
     $bVV = true;
 } else {
     $bVV = false;
@@ -64,7 +64,7 @@ $aVariants = preg_split('/\s*\n\s*/', trim($_REQUEST['var']));
 $aResponse = [];
 foreach ($aVariants as $sVariant) {
     $sVariant = trim($sVariant);
-    $HGVS = HGVS::checkVariant($sVariant)->allowMissingReferenceSequence();
+    $HGVS = LOVD\HGVS\HGVS::checkVariant($sVariant)->allowMissingReferenceSequence();
     $aVariant = $HGVS->getInfo();
 
     if (isset($aVariant['errors']['ENOTSUPPORTED'])) {

--- a/web/ajax.php
+++ b/web/ajax.php
@@ -39,7 +39,7 @@ if (empty($_REQUEST['var'])) {
 
 if (!empty($_REQUEST['callVV']) && $_REQUEST['callVV'] == 'true') {
     require '../variant_validator.php';
-    $_VV = new LOVD\HGVS\LOVD_VV();
+    $_VV = new LOVD\HGVS\VV();
     $bVV = true;
 } else {
     $bVV = false;

--- a/web/index.php
+++ b/web/index.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-12-03
- * Modified    : 2026-02-11
+ * Modified    : 2026-02-12
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -146,7 +146,7 @@ NC_000015.9:g.40699840C>T" rows="5"><?= (empty($_GET['multipleVariants']) || !is
     <div>
         LOVD/HGVS library version:
         <?php
-        $aVersions = HGVS::getVersions();
+        $aVersions = LOVD\HGVS\HGVS::getVersions();
         echo ($aVersions['library_version'] . ' (' . $aVersions['library_date'] . ')' ?? 'unknown');
         ?>
     </div>


### PR DESCRIPTION
### Add support for composer
- Add namespaces to all classes. This required me to overload `get_class()` so I didn't have to edit all uses of the original `get_class()`, which returns the full namespace as well.
- Renamed the VV class, which no longer needed to have a prefix. I used `LOVD_VV` instead of just `VV` to prevent name clashes, but with namespaces, we don't have this issue.
- Add `composer.json`. This allows the project to be used in `composer` environments.
- Update the manual.