### PR TITLE
Improve caches

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2026-02-12   // When modified, also change the library_version.
+ * Modified    : 2026-03-13   // When modified, also change the library_version.
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -801,8 +801,8 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_date' => '2026-02-12',
-            'library_version' => '1.0.0',
+            'library_date' => '2026-03-13',
+            'library_version' => '1.0.1',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',
@@ -815,6 +815,15 @@ class HGVS
                 'transcripts' => (file_exists(__DIR__ . '/cache/transcripts.json')? date('Y-m-d', filemtime(__DIR__ . '/cache/transcripts.json')) : null),
             ],
         ];
+    }
+
+
+
+
+
+    public function hasErrors ()
+    {
+        return (bool) $this->getMessagesByGroup('errors');
     }
 
 
@@ -844,6 +853,15 @@ class HGVS
         // This function checks if this class has a property called $sClassName.
         // A property is a matched object, stored in the $this->properties array.
         return ($this->properties && is_array($this->properties) && in_array($sClassName, $this->properties));
+    }
+
+
+
+
+
+    public function hasWarnings ()
+    {
+        return (bool) $this->getMessagesByGroup('warnings');
     }
 
 

--- a/caches.php
+++ b/caches.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2025-06-06
- * Modified    : 2026-02-12
+ * Modified    : 2026-03-10
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -419,4 +419,4 @@ class caches
     }
 }
 
-register_shutdown_function(['caches', 'shutdown']);
+register_shutdown_function(['LOVD\HGVS\caches', 'shutdown']);

--- a/caches.php
+++ b/caches.php
@@ -210,8 +210,27 @@ class caches
         }
         $aFile = @file($sFile, FILE_IGNORE_NEW_LINES);
         if ($aFile !== false) {
+            // If we're dealing with an old file, we should handle things a bit differently.
+            $bOldFormat = ($aFile[0][0] == '#');
+            if ($bOldFormat) {
+                // Remove the header.
+                array_shift($aFile);
+            }
+
             foreach ($aFile as $sLine) {
                 $aLine = explode("\t", $sLine, 2);
+                if (empty($aLine[1]) || ($bOldFormat && !substr($aLine[1], 0, 3) != 'NC_')) {
+                    // Skip empty answers or errors when reading the old format.
+                    continue;
+                } elseif (isset(self::$NC_cache[$aLine[0]])) {
+                    if (self::$NC_cache[$aLine[0]] == $aLine[1]) {
+                        // We have seen this variant before, and we already have this answer stored. Nothing to do.
+                        continue;
+                    }
+                    // We have seen this variant already, but we have a different value here.
+                    // This is a conflict we should let people know about.
+                    throw new \Exception("Conflict while merging cache files for {$aLine[0]}");
+                }
                 self::$NC_cache[$aLine[0]] = $aLine[1];
             }
             return true;

--- a/caches.php
+++ b/caches.php
@@ -149,7 +149,27 @@ class Caches
             return null;
         }
 
-        return (self::$NC_cache[$sNC] ?? false);
+        if (isset(self::$NC_cache[$sNC]) && self::$NC_cache[$sNC][0] != '{') {
+            return self::$NC_cache[$sNC];
+        }
+        return false;
+    }
+
+
+
+
+
+    public static function getErrors ($sNC)
+    {
+        // Gets the errors for a certain input.
+        if (!self::$NC_cache && !self::loadCorrectedNCs()) {
+            return null;
+        }
+
+        if (isset(self::$NC_cache[$sNC]) && self::$NC_cache[$sNC][0] == '{') {
+            return json_decode(self::$NC_cache[$sNC], true);
+        }
+        return false;
     }
 
 

--- a/caches.php
+++ b/caches.php
@@ -202,17 +202,18 @@ class caches
 
 
 
-    public static function loadCorrectedNCs ()
+    public static function loadCorrectedNCs (string $sFile = ''): bool
     {
         // Loads the NC cache when the data is requested.
-        $aFile = @file(self::$sFileNC, FILE_IGNORE_NEW_LINES);
+        if (!$sFile) {
+            $sFile = self::$sFileNC;
+        }
+        $aFile = @file($sFile, FILE_IGNORE_NEW_LINES);
         if ($aFile !== false) {
-            $aCache = [];
             foreach ($aFile as $sLine) {
                 $aLine = explode("\t", $sLine, 2);
-                $aCache[$aLine[0]] = $aLine[1];
+                self::$NC_cache[$aLine[0]] = $aLine[1];
             }
-            self::$NC_cache = $aCache;
             return true;
         }
 

--- a/caches.php
+++ b/caches.php
@@ -29,6 +29,11 @@ class Caches
     public static function buildCaches ($sVariant, $sBuild = false)
     {
         // Adds the given NC variant to both the NC and the mapping caches.
+        // Return values:
+        // true  : Success.
+        // 1     : Addition was not needed, variant already known.
+        // 0     : Internal failure with VV. Failure may be non-permanent.
+        // false : Internal failure when adding data to the cache. Failure is likely permanent.
         if ((!self::$NC_cache && !self::loadCorrectedNCs()) || (!self::$mapping_cache && !self::loadMappings())) {
             return null;
         }
@@ -49,7 +54,11 @@ class Caches
         // We assume that the variant is valid. If we validate it here and change it,
         //  the input of this function won't be usable for getCorrectedNC().
         // Check if we need to call VV.
-        if (self::hasCorrectedNC($sVariant)) {
+        if (self::hasErrors($sVariant)) {
+            // We've seen this variant before, and it has errors. There's nothing to do for us now.
+            return 1;
+
+        } elseif (self::hasCorrectedNC($sVariant)) {
             $sVariantCorrected = self::getCorrectedNC($sVariant);
             if (self::hasMapping($sVariantCorrected, $sBuild)) {
                 // Nothing to do.
@@ -64,6 +73,11 @@ class Caches
         // Call VV with the defaults and collect all information.
         $aVV = self::$oVV->verifyGenomic($sVariant, $aVVOptions);
         if (!$aVV || empty($aVV['data']['DNA'])) {
+            // If there are errors, store this.
+            if (!empty($aVV['errors'])) {
+                // There is a problem with the variant. Store the errors, so we won't repeat this request.
+                return self::setCorrectedNC($sVariant, json_encode($aVV['errors']));
+            }
             return 0; // Evaluates to false, indicates a VV or input error.
         }
 
@@ -179,9 +193,9 @@ class Caches
 
 
 
-    public static function hasError ($sNC)
+    public static function hasErrors ($sNC)
     {
-        // Checks if we have an error for a certain input.
+        // Checks if we have errors for a certain input.
         if (!self::$NC_cache && !self::loadCorrectedNCs()) {
             return null;
         }

--- a/caches.php
+++ b/caches.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2025-06-06
- * Modified    : 2026-03-10
+ * Modified    : 2026-03-11
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -15,7 +15,7 @@ namespace LOVD\HGVS;
 require_once 'HGVS.php';
 require_once 'variant_validator.php';
 
-class caches
+class Caches
 {
     // Class that handles the caches. Should be used statically.
     private static array $mapping_cache = [];
@@ -439,4 +439,4 @@ class caches
     }
 }
 
-register_shutdown_function(['LOVD\HGVS\caches', 'shutdown']);
+register_shutdown_function(['LOVD\HGVS\Caches', 'shutdown']);

--- a/caches.php
+++ b/caches.php
@@ -172,7 +172,21 @@ class Caches
             return null;
         }
 
-        return isset(self::$NC_cache[$sNC]);
+        return (isset(self::$NC_cache[$sNC]) && self::$NC_cache[$sNC][0] != '{');
+    }
+
+
+
+
+
+    public static function hasError ($sNC)
+    {
+        // Checks if we have an error for a certain input.
+        if (!self::$NC_cache && !self::loadCorrectedNCs()) {
+            return null;
+        }
+
+        return (isset(self::$NC_cache[$sNC]) && self::$NC_cache[$sNC][0] == '{');
     }
 
 


### PR DESCRIPTION
### Improve the caches
- Fix the shutdown function after the recent change to namespaces.
- Prepare the code for loading multiple NC caches.
- Update `loadCorrectedNCs()` to also support the older NC cache format. This effectively allows the library to merge and clean NC caches directly, without the need for external tools. Simply let it load all the caches, and write out the data file.
- Standardize the caches class name to Caches. PHP classes are case-insensitive, so otherwise it doesn't matter, but the standard is to use capitalized class names.
- Add `hasError()` and update `hasCorrectedNC()`. This prepares the caches for storing errors in the NC cache. The new method `hasError()` allows us to check for errors, and the method `hasCorrectedNC()` has been updated to no longer return true in case an error is stored.
- Update `buildCaches()` to handle variant errors.
- Add `getErrors()` and update `getCorrectedNC()`. The same separation applies; one gets the errors, the other one the corrected variant.
- Add `HGVS->hasErrors()` and `hasWarnings()` and bump the version.