### PR TITLE
Add VariantValidator authorization option.

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -801,8 +801,8 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_date' => '2026-03-13',
-            'library_version' => '1.0.1',
+            'library_date' => '2026-03-17',
+            'library_version' => '1.1.0',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',

--- a/caches.php
+++ b/caches.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2025-06-06
- * Modified    : 2026-03-11
+ * Modified    : 2026-03-17
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -20,6 +20,7 @@ class Caches
     // Class that handles the caches. Should be used statically.
     private static array $mapping_cache = [];
     private static array $NC_cache = [];
+    private static array $aVV = ['url' => '', 'auth_token' => ''];
     private static int $nNewMappingsSinceWrite = 0;
     private static int $nNewNCsSinceWrite = 0;
     private static string $sFileMapping = __DIR__ . '/cache/mapping.txt';
@@ -67,7 +68,7 @@ class Caches
         }
         // Initiate VV if not already done so.
         if (!self::$oVV) {
-            self::$oVV = new VV();
+            self::$oVV = new VV(self::$aVV['url'], self::$aVV['auth_token']);
         }
 
         // Call VV with the defaults and collect all information.
@@ -393,6 +394,23 @@ class Caches
         }
 
         return true;
+    }
+
+
+
+
+
+    public static function setVVOptions (array $aOptions): void
+    {
+        // Overwrite VV options (URL, auth token) with new values.
+        foreach ($aOptions as $sKey => $sValue) {
+            self::$aVV[$sKey] = $sValue;
+        }
+
+        // If we have an object already, destroy it.
+        if (self::$oVV) {
+            self::$oVV = false;
+        }
     }
 
 

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -528,6 +528,11 @@ class VV
         }
         if (!$aJSON || empty($aJSON['transcripts'])) {
             // Failure.
+            if (!empty($aJSON['errors'])) {
+                // Errors from callVV(), like HTTP 401. Just return that.
+                return $aJSON;
+            }
+
             // OK, but... what if we were working on chrM? And VV doesn't support these yet?
             if ($aJSON && isset($aJSON['current_symbol']) && substr($aJSON['current_symbol'], 0, 3) == 'MT-') {
                 // Collect all NCs and builds for chrM.
@@ -660,6 +665,7 @@ class VV
     public function test ()
     {
         // Tests the VV endpoint.
+        // NOTE: This does not detect whether this VV endpoint needs authorization. Apparently, the hello endpoint is unprotected always.
 
         $aJSON = $this->callVV('hello');
         if (!$aJSON) {
@@ -773,6 +779,11 @@ class VV
             // Failure. This happens when VV fails hard or if we can't find our input back in the output.
             // We should have stopped unsupported variant descriptions because we already checked for WNOTSUPPORTED.
             // So this should be an VV error.
+            if (!empty($aJSON['errors'])) {
+                // Errors from callVV(), like HTTP 401. Just return that.
+                return $aJSON;
+            }
+
             return false;
         }
 
@@ -1076,6 +1087,11 @@ class VV
             // Failure. This happens when VV fails hard.
             // We should have stopped unsupported variant descriptions because we already checked for WNOTSUPPORTED.
             // So this should be an VV error.
+            if (!empty($aJSON['errors'])) {
+                // Errors from callVV(), like HTTP 401. Just return that.
+                return $aJSON;
+            }
+
             return false;
         }
 

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -253,6 +253,9 @@ class VV
                 curl_setopt($hCurl, CURLOPT_FOLLOWLOCATION, true); // Make sure we follow redirects.
                 // Set a version so that VV can recognize us.
                 curl_setopt($hCurl, CURLOPT_USERAGENT, 'LOVD/VV:' . HGVS::getVersions()['library_version']);
+                if ($this->sAuthToken) {
+                    curl_setopt($hCurl, CURLOPT_HTTPHEADER, ["Authorization: Bearer {$this->sAuthToken}"]);
+                }
 
                 // Set proxy, if we are used from within LOVD and LOVD requires a proxy.
                 if (!empty($_CONF['proxy_host'])) {
@@ -264,20 +267,30 @@ class VV
             }
 
             curl_setopt($hCurl, CURLOPT_URL, $sURL);
-            $sJSONResponse = curl_exec($hCurl);
+            $sJSONResponse = @curl_exec($hCurl);
 
         } elseif (function_exists('lovd_php_file')) {
             // Backup method, no curl installed. We'll try LOVD's file() implementation, which also handles proxies.
-            $aJSONResponse = lovd_php_file($sURL);
+            if (!$this->sAuthToken) {
+                $aJSONResponse = @lovd_php_file($sURL);
+            } else {
+                $aJSONResponse = @lovd_php_file($sURL, false, false, ["Authorization: Bearer {$this->sAuthToken}"]);
+            }
             if ($aJSONResponse !== false) {
                 $sJSONResponse = implode("\n", $aJSONResponse);
             }
 
         } else {
             // Last fallback. Requires fopen wrappers.
-            $aJSONResponse = file($sURL);
-            if ($aJSONResponse !== false) {
-                $sJSONResponse = implode("\n", $aJSONResponse);
+            if (!$this->sAuthToken) {
+                $sJSONResponse = @file_get_contents($sURL);
+            } else {
+                $Context = stream_context_create([
+                    'http' => [
+                        'header' => "Authorization: Bearer {$this->sAuthToken}",
+                    ]
+                ]);
+                $sJSONResponse = @file_get_contents($sURL, 0, $Context);
             }
         }
 

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -301,7 +301,26 @@ class VV
             if ($aJSONResponse !== false) {
                 return $aJSONResponse;
             }
+
+        } else {
+            // Analyze the headers to see if this was an HTTP 401.
+            if (function_exists('http_get_last_response_headers')) {
+                // Relatively new, but was introduced very shortly before $http_response_header was deprecated.
+                $sHTTP = (http_get_last_response_headers()[0] ?? '');
+            } else {
+                $sHTTP = ($http_response_header[0] ?? '');
+            }
+            if (strpos($sHTTP, ' 401 UNAUTHORIZED')) {
+                // This API endpoint needs authorization. Did we provide any?
+                if ($this->sAuthToken) {
+                    // Apparently, we did...
+                    return ['errors' => 'Authentication failed; API token rejected.'];
+                } else {
+                    return ['errors' => 'Authentication failed; please generate an API token.'];
+                }
+            }
         }
+
         // Something went wrong...
         return false;
     }

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -314,9 +314,19 @@ class VV
                 // This API endpoint needs authorization. Did we provide any?
                 if ($this->sAuthToken) {
                     // Apparently, we did...
-                    return ['errors' => 'Authentication failed; API token rejected.'];
+                    return array_merge(
+                        $this->aResponse,
+                        [
+                            'errors' => 'Authentication failed; API token rejected.',
+                        ]
+                    );
                 } else {
-                    return ['errors' => 'Authentication failed; please generate an API token.'];
+                    return array_merge(
+                        $this->aResponse,
+                        [
+                            'errors' => 'Authentication failed; please generate an API token.',
+                        ]
+                    );
                 }
             }
         }

--- a/variant_validator.php
+++ b/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2026-02-12
+ * Modified    : 2026-03-16
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -21,6 +21,7 @@ class VV
     // This class defines the LOVD VV object, handling all Variant Validator calls.
 
     public $sURL = 'https://rest.variantvalidator.org/'; // The URL of the VV endpoint.
+    private $sAuthToken = ''; // API token for endpoints protected by authorization.
     public $aResponse = array( // The standard response body.
         'data' => array(),
         'messages' => array(),
@@ -34,13 +35,17 @@ class VV
 
 
 
-    function __construct ($sURL = '')
+    function __construct ($sURL = '', $sAuthToken = '')
     {
         // Initiates the VV object. Nothing much to do except for filling in the URL.
 
         if ($sURL) {
             // We don't test given URLs, that would take too much time.
             $this->sURL = rtrim($sURL, '/') . '/';
+        }
+        if ($sAuthToken) {
+            // We don't test given tokens, that would take too much time.
+            $this->sAuthToken = $sAuthToken;
         }
         // __construct() should return void.
     }


### PR DESCRIPTION
### Add VariantValidator authorization option
- Add option to store an API token.
- Use the authentication token for all three methods of communication.
- Notice HTTP 401 from VV and report errors.
- Better return a full response in case of HTTP 401 errors.
- Make sure that `callVV()` errors are returned to the user.
- Make sure the Caches class can use the new VV options. Since Caches is implemented as a static class, we don't have a constructor. So we have to create a function for it. When it's called, make sure we destroy the current VV object, so a new one will be created with the new settings.
- Bump the version and the library date.