### PR TITLE
Add support for CNVs.

### DIFF
--- a/HGVS.php
+++ b/HGVS.php
@@ -1523,9 +1523,10 @@ class HGVS_ChromosomeNumber extends HGVS
 class HGVS_CNV extends HGVS
 {
     public array $patterns = [
-        'full'  => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
-        'short' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
-        'del'   => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'del(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
+        '2_positions' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
+        '4_positions' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPositions', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ')', []],
+        'short'       => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
+        'del'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'del(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
     ];
 
     public function validate ()
@@ -1533,7 +1534,16 @@ class HGVS_CNV extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         // First, determine the variant type based on the CopyNumber.
         $sChr = strtoupper($this->Chromosome->getValue());
-        switch (($this->hasProperty('CNVCopyNumber')? $this->CNVCopyNumber->getCorrectedValue() : '?')) {
+        $sCopyNumber = '?';
+        if ($this->hasProperty('CNVCopyNumber')) {
+            if (is_array($this->CNVCopyNumber)) {
+                // Four positions given. The middle copy number determines the variant type.
+                $sCopyNumber = $this->CNVCopyNumber[1]->getCorrectedValue();
+            } else {
+                $sCopyNumber = $this->CNVCopyNumber->getCorrectedValue();
+            }
+        }
+        switch ($sCopyNumber) {
             case '0':
                 $sVariantType = 'del';
                 $sZygosity = 'homozygous';
@@ -1581,12 +1591,15 @@ class HGVS_CNV extends HGVS
         $this->corrected_values = $this->buildCorrectedValues(
             $this->Chromosome->getCorrectedValue(),
             ':g.(',
-            ($this->getMatchedPattern() == 'full'?
+            ($this->getMatchedPattern() == '2_positions'?
                 $this->DNAPositions->getCorrectedValue() :
-                ($this->hasProperty('ChromosomeBands')?
-                    implode('_', $this->ChromosomeBands->getPositions($this->Genome->getCorrectedValue(), strtoupper($this->Chromosome->getValue()))) :
-                    'pter_qter')
-            ),
+                ($this->getMatchedPattern() == '4_positions'?
+                    $this->DNAPosition[0]->getCorrectedValue() . '_' .
+                    str_replace('_', ')_(', $this->DNAPositions->getCorrectedValue()) . '_' .
+                    $this->DNAPosition[1]->getCorrectedValue() :
+                    ($this->hasProperty('ChromosomeBands')?
+                        implode('_', $this->ChromosomeBands->getPositions($this->Genome->getCorrectedValue(), strtoupper($this->Chromosome->getValue()))) :
+                        'pter_qter'))),
             ')',
             $sVariantType
         );

--- a/HGVS.php
+++ b/HGVS.php
@@ -1631,8 +1631,8 @@ class HGVS_CNVCopyNumber extends HGVS
 class HGVS_CNVMethod extends HGVS
 {
     public array $patterns = [
-        'array'      => ['arr', []],
-        'sequencing' => ['seq', []],
+        'array'      => ['/arr/', []],
+        'sequencing' => ['/seq/', []],
     ];
 }
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -1580,13 +1580,14 @@ class HGVS_CNV extends HGVS
         // The build is not needed; the Chromosome object has used it already.
         $this->corrected_values = $this->buildCorrectedValues(
             $this->Chromosome->getCorrectedValue(),
-            ':g.',
+            ':g.(',
             ($this->getMatchedPattern() == 'full'?
                 $this->DNAPositions->getCorrectedValue() :
                 ($this->hasProperty('ChromosomeBands')?
                     implode('_', $this->ChromosomeBands->getPositions($this->Genome->getCorrectedValue(), strtoupper($this->Chromosome->getValue()))) :
                     'pter_qter')
             ),
+            ')',
             $sVariantType
         );
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -1525,6 +1525,7 @@ class HGVS_CNV extends HGVS
     public array $patterns = [
         'full'  => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
         'short' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
+        'del'   => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'del(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
     ];
 
     public function validate ()
@@ -1532,7 +1533,7 @@ class HGVS_CNV extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         // First, determine the variant type based on the CopyNumber.
         $sChr = strtoupper($this->Chromosome->getValue());
-        switch ($this->CNVCopyNumber->getCorrectedValue()) {
+        switch (($this->hasProperty('CNVCopyNumber')? $this->CNVCopyNumber->getCorrectedValue() : '?')) {
             case '0':
                 $sVariantType = 'del';
                 $sZygosity = 'homozygous';
@@ -1567,7 +1568,12 @@ class HGVS_CNV extends HGVS
                 break;
 
             default:
-                $sVariantType = '?';
+                // We also get here for the "del(X)" notation.
+                if ($this->getMatchedPattern() == 'del') {
+                    $sVariantType = 'del';
+                } else {
+                    $sVariantType = '?';
+                }
                 $sZygosity = 'unknown';
         }
 
@@ -1577,7 +1583,9 @@ class HGVS_CNV extends HGVS
             ':g.',
             ($this->getMatchedPattern() == 'full'?
                 $this->DNAPositions->getCorrectedValue() :
-                'pter_qter'
+                ($this->hasProperty('ChromosomeBands')?
+                    implode('_', $this->ChromosomeBands->getPositions($this->Genome->getCorrectedValue(), strtoupper($this->Chromosome->getValue()))) :
+                    'pter_qter')
             ),
             $sVariantType
         );
@@ -1592,6 +1600,12 @@ class HGVS_CNV extends HGVS
                 'platform' => $this->CNVMethod->getMatchedPattern(),
             ]
         );
+
+        if (!$HGVSVariant->isValid()) {
+            // This happens when chromosome bands are given that aren't found in our dataset.
+            $this->messages['EINVALIDCYTOBAND'] =
+                'The given cytoband ' . $this->ChromosomeBands->getCorrectedValue() . ' is not found in chromosome ' . strtoupper($this->Chromosome->getValue()) . '.';
+        }
 
         // We could have triggered a whitespace warning, but that's normal for us.
         unset($this->messages['WWHITESPACE']);

--- a/HGVS.php
+++ b/HGVS.php
@@ -849,8 +849,8 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_date' => '2026-04-14',
-            'library_version' => '1.1.2',
+            'library_date' => '2026-06-05',
+            'library_version' => '1.2.0',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',
@@ -1647,6 +1647,7 @@ class HGVS_CNV extends HGVS
         $this->data = array_merge(
             $HGVSVariant->getData(),
             [
+                'type' => $sVariantType, // In case the variant is broken, and it doesn't provide this.
                 'zygosity' => $sZygosity,
                 'platform' => $this->CNVMethod->getMatchedPattern(),
             ]

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2026-06-04   // When modified, also change the library_version.
+ * Modified    : 2026-06-05   // When modified, also change the library_version.
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1397,7 +1397,7 @@ class HGVS_Chromosome extends HGVS
 class HGVS_ChromosomeBand extends HGVS
 {
     public array $patterns = [
-        'band' => ['/[pq][0-9]+(\.[0-9]+)?/', []],
+        'band' => ['/[pq]\.?[0-9]+(\.[0-9]+)?/', []],
         'ter'  => ['/[p|q]ter/', []],
     ];
     public static array $cytobands = [];

--- a/HGVS.php
+++ b/HGVS.php
@@ -1444,8 +1444,9 @@ class HGVS_ChromosomeBand extends HGVS
             // We have this band stored.
             return $aBands[$this->getCorrectedValue()];
         } else {
-            // For now, just return nothing. We could try to think of something clever, but bad bands would just make us guess, anyway...
-            return [];
+            // For now, just return the given input.
+            // We could try to think of something clever, but bad bands would just make us guess, anyway...
+            return [$this->getCorrectedValue(), $this->getCorrectedValue()];
         }
     }
 
@@ -1617,7 +1618,7 @@ class HGVS_CNV extends HGVS
                     str_replace('_', ')_(', $this->DNAPositions->getCorrectedValue()) . '_' .
                     $this->DNAPosition[1]->getCorrectedValue() :
                     ($this->hasProperty('ChromosomeBands')?
-                        implode('_', $this->ChromosomeBands->getPositions($this->Genome->getCorrectedValue(), strtoupper($this->Chromosome->getValue()))) :
+                        implode('_', array_unique($this->ChromosomeBands->getPositions($this->Genome->getCorrectedValue(), strtoupper($this->Chromosome->getValue())))) :
                         'pter_qter'))),
             ')',
             $sVariantType

--- a/HGVS.php
+++ b/HGVS.php
@@ -1529,6 +1529,7 @@ class HGVS_CNV extends HGVS
         'short'       => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
         'del'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'del(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
         'dup'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'dup(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
+        'trp'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'trp(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
     ];
 
     public function validate ()
@@ -1592,13 +1593,16 @@ class HGVS_CNV extends HGVS
                 break;
 
             default:
-                // We also get here for the "del(X)" and "dup(X)" notation.
+                // We also get here for the "del(X)", "dup(X)", and "trp(X)" notations.
+                $sZygosity = 'unknown';
                 if (in_array($this->getMatchedPattern(), ['del', 'dup'])) {
                     $sVariantType = $this->getMatchedPattern();
+                } elseif ($this->getMatchedPattern() == 'trp') {
+                    $sVariantType = 'dup';
+                    $sZygosity = 'homozygous';
                 } else {
                     $sVariantType = '?';
                 }
-                $sZygosity = 'unknown';
         }
 
         // The build is not needed; the Chromosome object has used it already.

--- a/HGVS.php
+++ b/HGVS.php
@@ -1451,6 +1451,29 @@ class HGVS_ChromosomeNumber extends HGVS
 
 
 
+class HGVS_CNVCopyNumber extends HGVS
+{
+    public array $patterns = [
+        ['/[0-9]/', []],
+    ];
+}
+
+
+
+
+
+class HGVS_CNVMethod extends HGVS
+{
+    public array $patterns = [
+        'array'      => ['arr', []],
+        'sequencing' => ['seq', []],
+    ];
+}
+
+
+
+
+
 class HGVS_Colon extends HGVS
 {
     public array $patterns = [

--- a/HGVS.php
+++ b/HGVS.php
@@ -1400,6 +1400,58 @@ class HGVS_ChromosomeBand extends HGVS
         'band' => ['/[pq][0-9]+(\.[0-9]+)?/', []],
         'ter'  => ['/[p|q]ter/', []],
     ];
+    public static array $cytobands = [];
+
+    public function loadData ()
+    {
+        // Load the cytoband data, if present. We can then validate cytobands properly and provide detailed info.
+        if (self::$cytobands) {
+            return true;
+        } else {
+            // We haven't loaded the file yet, find and load it.
+            $sFile = dirname(__FILE__) . '/cache/cytobands.json';
+            if (is_readable($sFile)) {
+                $sJSON = @file_get_contents($sFile);
+                if ($sJSON) {
+                    $aJSON = @json_decode($sJSON, true);
+                    if ($aJSON !== false && array_keys($aJSON) == ['hg19', 'hg38']) {
+                        self::$cytobands = $aJSON;
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+
+
+
+
+    public function getPositions (string $sBuild, string $sChromosome)
+    {
+        // Translate the chromosome bands into genomic positions useful for HGVS descriptions.
+        if (!self::loadData() || !isset(self::$cytobands[$sBuild]) || !isset(self::$cytobands[$sBuild][$sChromosome])) {
+            return [];
+        }
+
+        $aBands = self::$cytobands[$sBuild][$sChromosome];
+        if ($this->getCorrectedValue() == 'pter') {
+            return current($aBands);
+        } elseif ($this->getCorrectedValue() == 'qter') {
+            return $aBands[array_key_last($aBands)];
+        } elseif (isset($aBands[$this->getCorrectedValue()])) {
+            // We have this band stored.
+            return $aBands[$this->getCorrectedValue()];
+        } else {
+            // For now, just return nothing. We could try to think of something clever, but bad bands would just make us guess, anyway...
+            return [];
+        }
+    }
+
+
+
+
 
     public function validate ()
     {
@@ -1419,6 +1471,21 @@ class HGVS_ChromosomeBands extends HGVS
         'range'  => ['HGVS_ChromosomeBand', 'HGVS_ChromosomeBand', []],
         'single' => ['HGVS_ChromosomeBand', []],
     ];
+
+    public function getPositions (string $sBuild, string $sChromosome)
+    {
+        // Translate the chromosome bands into genomic positions useful for HGVS descriptions.
+        if ($this->getMatchedPattern() == 'single') {
+            return $this->ChromosomeBand->getPositions($sBuild, $sChromosome);
+        } else {
+            // This assumes that the bands are given in the correct order.
+            // We do not currently have a method to sort them.
+            return [
+                $this->ChromosomeBand[0]->getPositions($sBuild, $sChromosome)[0],
+                $this->ChromosomeBand[1]->getPositions($sBuild, $sChromosome)[1]
+            ];
+        }
+    }
 }
 
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -1437,9 +1437,11 @@ class HGVS_ChromosomeBand extends HGVS
 
         $aBands = self::$cytobands[$sBuild][$sChromosome];
         if ($this->getCorrectedValue() == 'pter') {
-            return current($aBands);
+            // Return pter's positions, but replace "1" by "pter".
+            return ['pter'] + current($aBands);
         } elseif ($this->getCorrectedValue() == 'qter') {
-            return $aBands[array_key_last($aBands)];
+            // Return qter's positions, but replace the last value by "qter".
+            return [1 => 'qter'] + $aBands[array_key_last($aBands)];
         } elseif (isset($aBands[$this->getCorrectedValue()])) {
             // We have this band stored.
             return $aBands[$this->getCorrectedValue()];

--- a/HGVS.php
+++ b/HGVS.php
@@ -1526,6 +1526,7 @@ class HGVS_CNV extends HGVS
         '2_positions' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
         '2_pos_2_chr' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBand', 'HGVS_Chromosome', 'HGVS_ChromosomeBand', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
         '4_positions' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPositions', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ')', []],
+        '2_bands'     => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', '(', 'HGVS_Chromosome', ')', '(', 'HGVS_ChromosomeBands', ')', 'x', 'HGVS_CNVCopyNumber', []],
         'short'       => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
         'del'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'del(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
         'dup'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'dup(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],

--- a/HGVS.php
+++ b/HGVS.php
@@ -1456,7 +1456,8 @@ class HGVS_ChromosomeNumber extends HGVS
 class HGVS_CNV extends HGVS
 {
     public array $patterns = [
-        ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
+        'full'  => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
+        'short' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
     ];
 
     public function validate ()
@@ -1507,7 +1508,10 @@ class HGVS_CNV extends HGVS
         $this->corrected_values = $this->buildCorrectedValues(
             $this->Chromosome->getCorrectedValue(),
             ':g.',
-            $this->DNAPositions->getCorrectedValue(),
+            ($this->getMatchedPattern() == 'full'?
+                $this->DNAPositions->getCorrectedValue() :
+                'pter_qter'
+            ),
             $sVariantType
         );
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -2695,14 +2695,22 @@ class HGVS_DNAPosition extends HGVS
 
         // Reset the limits if we have a known NC.
         $RefSeq = $this->getParentProperty('ReferenceSequence');
+        $Chromosome = $this->getParentProperty('Chromosome');
         if ($RefSeq) {
             $aRefSeqInfo = HGVS_Chromosome::getInfoByNC($RefSeq->getCorrectedValue());
-            if ($aRefSeqInfo) {
-                $nMaxPosition = HGVS_ChromosomeBand::getMaximumPosition($aRefSeqInfo['build'], $aRefSeqInfo['chr']);
-                if ($nMaxPosition) {
-                    // We have a numeric value for qter.
-                    $this->position_limits[1] = $nMaxPosition;
-                }
+        } elseif ($Chromosome) {
+            if (is_array($Chromosome)) {
+                $Chromosome = $Chromosome[0];
+            }
+            $aRefSeqInfo = HGVS_Chromosome::getInfoByNC($Chromosome->getCorrectedValue());
+        }
+        if (!empty($aRefSeqInfo)) {
+            // Try to get the maximum position for this chromosome.
+            // Note that we check for $nMaxPosition later in the code as well.
+            $nMaxPosition = HGVS_ChromosomeBand::getMaximumPosition($aRefSeqInfo['build'], $aRefSeqInfo['chr']);
+            if ($nMaxPosition) {
+                // We have a numeric value for qter.
+                $this->position_limits[1] = $nMaxPosition;
             }
         }
 
@@ -2772,6 +2780,15 @@ class HGVS_DNAPosition extends HGVS
                 if ($RefSeq && $RefSeq->molecule_type != 'genome_transcript') {
                     $this->messages['EWRONGREFERENCE'] =
                         'To verify intronic positions, add a genomic context to the transcript reference sequence.';
+                }
+
+            } elseif (!empty($nMaxPosition) && $sVariantPrefix == 'g') {
+                // Correct genomic positions, so we'll try to use pter and qter where we can.
+                // However, we're not doing this for circular genomes.
+                if ($this->position == 1) {
+                    $this->setCorrectedValue('pter');
+                } elseif ($this->position == $nMaxPosition) {
+                    $this->setCorrectedValue('qter');
                 }
             }
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2026-04-14   // When modified, also change the library_version.
+ * Modified    : 2026-06-01   // When modified, also change the library_version.
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1387,6 +1387,37 @@ class HGVS_Chromosome extends HGVS
             $this->addCorrectedValue(self::$refseqs['hg18'][$sChr], 0.05);
         }
     }
+}
+
+
+
+
+
+class HGVS_ChromosomeBand extends HGVS
+{
+    public array $patterns = [
+        'band' => ['/[pq][0-9]+(\.[0-9]+)?/', []],
+        'ter'  => ['/[p|q]ter/', []],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(strtolower($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+    }
+}
+
+
+
+
+
+class HGVS_ChromosomeBands extends HGVS
+{
+    public array $patterns = [
+        'range'  => ['HGVS_ChromosomeBand', 'HGVS_ChromosomeBand', []],
+        'single' => ['HGVS_ChromosomeBand', []],
+    ];
 }
 
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -1528,6 +1528,7 @@ class HGVS_CNV extends HGVS
         '4_positions' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPositions', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ')', []],
         'short'       => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
         'del'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'del(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
+        'dup'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'dup(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
     ];
 
     public function validate ()
@@ -1591,9 +1592,9 @@ class HGVS_CNV extends HGVS
                 break;
 
             default:
-                // We also get here for the "del(X)" notation.
-                if ($this->getMatchedPattern() == 'del') {
-                    $sVariantType = 'del';
+                // We also get here for the "del(X)" and "dup(X)" notation.
+                if (in_array($this->getMatchedPattern(), ['del', 'dup'])) {
+                    $sVariantType = $this->getMatchedPattern();
                 } else {
                     $sVariantType = '?';
                 }

--- a/HGVS.php
+++ b/HGVS.php
@@ -1402,7 +1402,7 @@ class HGVS_ChromosomeBand extends HGVS
     ];
     public static array $cytobands = [];
 
-    public function loadData ()
+    public static function loadData ()
     {
         // Load the cytoband data, if present. We can then validate cytobands properly and provide detailed info.
         if (self::$cytobands) {
@@ -1422,6 +1422,21 @@ class HGVS_ChromosomeBand extends HGVS
             }
         }
         return false;
+    }
+
+
+
+
+
+    public static function getMaximumPosition (string $sBuild, string $sChromosome)
+    {
+        // Gets the last position for a given chromosome.
+        if (!self::loadData() || !isset(self::$cytobands[$sBuild]) || !isset(self::$cytobands[$sBuild][$sChromosome])) {
+            return false;
+        }
+
+        $aBands = self::$cytobands[$sBuild][$sChromosome];
+        return $aBands[array_key_last($aBands)][1];
     }
 
 
@@ -2678,6 +2693,19 @@ class HGVS_DNAPosition extends HGVS
         $this->ISCN = false;
         $this->position_limits = $this->position_limits[$sVariantPrefix];
 
+        // Reset the limits if we have a known NC.
+        $RefSeq = $this->getParentProperty('ReferenceSequence');
+        if ($RefSeq) {
+            $aRefSeqInfo = HGVS_Chromosome::getInfoByNC($RefSeq->getCorrectedValue());
+            if ($aRefSeqInfo) {
+                $nMaxPosition = HGVS_ChromosomeBand::getMaximumPosition($aRefSeqInfo['build'], $aRefSeqInfo['chr']);
+                if ($nMaxPosition) {
+                    // We have a numeric value for qter.
+                    $this->position_limits[1] = $nMaxPosition;
+                }
+            }
+        }
+
         if ($this->matched_pattern == 'unknown') {
             $this->UTR = false;
             $this->position = $this->value;
@@ -2695,7 +2723,6 @@ class HGVS_DNAPosition extends HGVS
                 // There really was a prefix, so complain that they used the wrong one.
                 $this->messages['EWRONGPREFIX'] = 'Chromosomal positions pter and qter can only be reported using the "g." genomic prefix.';
             }
-            $RefSeq = $this->getParentProperty('ReferenceSequence');
             if ($RefSeq && $RefSeq->molecule_type != 'chromosome') {
                 $this->messages['EWRONGREFERENCE'] =
                     'A chromosomal reference sequence is required for pter or qter positions.';

--- a/HGVS.php
+++ b/HGVS.php
@@ -1429,8 +1429,9 @@ class HGVS_ChromosomeNumber extends HGVS
 {
     public array $patterns = [
         'number' => ['/[0-9]{1,2}(?![0-9])/', []],
-        'X'      => ['/X(?![A-Z])/', []],
-        'Y'      => ['/Y(?![A-Z])/', []],
+        // Deliberately allow Xp, Xq, Yp, and Yq to be recognized as a Chromosome.
+        'X'      => ['/X(?![A-O,R-Z])/', []],
+        'Y'      => ['/Y(?![A-O,R-Z])/', []],
         'M'      => ['/M(?![A-Z])/', []],
     ];
 

--- a/HGVS.php
+++ b/HGVS.php
@@ -1397,7 +1397,7 @@ class HGVS_Chromosome extends HGVS
 class HGVS_ChromosomeBand extends HGVS
 {
     public array $patterns = [
-        'band' => ['/[pq]\.?[0-9]+(\.[0-9]+)?/', []],
+        'band' => ['/[pq]\.?[0-9]+(\s?\.\s?[0-9]+)?/', []],
         'ter'  => ['/[p|q]ter/', []],
     ];
     public static array $cytobands = [];

--- a/HGVS.php
+++ b/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2026-06-01   // When modified, also change the library_version.
+ * Modified    : 2026-06-04   // When modified, also change the library_version.
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1524,6 +1524,7 @@ class HGVS_CNV extends HGVS
 {
     public array $patterns = [
         '2_positions' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
+        '2_pos_2_chr' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBand', 'HGVS_Chromosome', 'HGVS_ChromosomeBand', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
         '4_positions' => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPositions', 'x', 'HGVS_CNVCopyNumber', ',', 'HGVS_DNAPosition', 'x', 'HGVS_CNVCopyNumber', ')', []],
         'short'       => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'seq(', 'HGVS_Chromosome', ')', 'x', 'HGVS_CNVCopyNumber', []],
         'del'         => ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'del(', 'HGVS_Chromosome', ')(', 'HGVS_ChromosomeBands', ')', []],
@@ -1532,6 +1533,18 @@ class HGVS_CNV extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
+        // First, handle having multiple chromosomes in the description.
+        if ($this->getMatchedPattern() == '2_pos_2_chr') {
+            // They need to match, otherwise, what's going on?
+            if ($this->Chromosome[0]->getCorrectedValue() != $this->Chromosome[1]->getCorrectedValue()) {
+                return false; // Break out of the entire object.
+            } else {
+                // To simplify handling the description:
+                $this->Chromosome = $this->Chromosome[0];
+                $this->matched_pattern = '2_positions';
+            }
+        }
+
         // First, determine the variant type based on the CopyNumber.
         $sChr = strtoupper($this->Chromosome->getValue());
         $sCopyNumber = '?';

--- a/HGVS.php
+++ b/HGVS.php
@@ -82,6 +82,7 @@ class HGVS
         'full_variant'       => ['HGVS_ReferenceSequence', 'HGVS_Colon', 'HGVS_Variant', []],
         'variant'            => ['HGVS_Variant', ['EREFSEQMISSING' => 'This variant is missing a reference sequence.']],
         'ANNOVAR'            => ['HGVS_ANNOVAR', ['WANNOVAR' => 'Recognized an ANNOVAR format. Please note that ANNOVAR produces invalid variant descriptions. We recommend using a tool that produces valid HGVS nomenclature-compliant descriptions.']],
+        'CNV'                => ['HGVS_CNV', ['WCNV' => 'Recognized a CNV-like format; converting this format to HGVS nomenclature.']],
         'VCF'                => ['HGVS_VCF', ['WVCF' => 'Recognized a VCF-like format; converting this format to HGVS nomenclature.']],
         'reference_sequence' => ['HGVS_ReferenceSequence', []],
         'gene'               => ['HGVS_Gene', []],
@@ -1444,6 +1445,84 @@ class HGVS_ChromosomeNumber extends HGVS
                 $this->messages['EINVALIDCHROMOSOME'] = 'This variant description contains an invalid chromosome number: "' . $this->value . '".';
             }
         }
+    }
+}
+
+
+
+
+
+class HGVS_CNV extends HGVS
+{
+    public array $patterns = [
+        ['HGVS_CNVMethod', '[', 'HGVS_Genome', ']', 'HGVS_Chromosome', 'HGVS_ChromosomeBands', '(', 'HGVS_DNAPositions', ')', 'x', 'HGVS_CNVCopyNumber', []],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        // First, determine the variant type based on the CopyNumber.
+        $sChr = strtoupper($this->Chromosome->getValue());
+        switch ($this->CNVCopyNumber->getCorrectedValue()) {
+            case '0':
+                $sVariantType = 'del';
+                $sZygosity = 'homozygous';
+                break;
+
+            case '1':
+                $sVariantType = 'del';
+                $sZygosity = 'heterozygous';
+                break;
+
+            case '2':
+                // For sex chromosomes, this depends on the sex of the patient. We don't have that info, so we're guessing.
+                if ($sChr == 'X' || $sChr == 'Y') {
+                    // Probably a duplication in a male.
+                    $sVariantType = 'dup';
+                    $sZygosity = 'hemizygous';
+                } else {
+                    // Autosome; probably normal? Or maybe they wanted to indicate an inversion?
+                    $sVariantType = '=';
+                    $sZygosity = 'homozygous';
+                }
+                break;
+
+            case '3':
+                $sVariantType = 'dup';
+                $sZygosity = 'heterozygous';
+                break;
+
+            case '4':
+                $sVariantType = 'dup';
+                $sZygosity = 'homozygous';
+                break;
+
+            default:
+                $sVariantType = '?';
+                $sZygosity = 'unknown';
+        }
+
+        // The build is not needed; the Chromosome object has used it already.
+        $this->corrected_values = $this->buildCorrectedValues(
+            $this->Chromosome->getCorrectedValue(),
+            ':g.',
+            $this->DNAPositions->getCorrectedValue(),
+            $sVariantType
+        );
+
+        // We also need to store the data fields. Yes, this is duplicated work.
+        // However, it's much simpler to do it like this.
+        $HGVSVariant = new HGVS($this->getCorrectedValue(), null, $this->debugging);
+        $this->data = array_merge(
+            $HGVSVariant->getData(),
+            [
+                'zygosity' => $sZygosity,
+                'platform' => $this->CNVMethod->getMatchedPattern(),
+            ]
+        );
+
+        // We could have triggered a whitespace warning, but that's normal for us.
+        unset($this->messages['WWHITESPACE']);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For pro users, this means that `requireVariant()` and `allowMissingReferenceSequ
 
 
 ### The LOVD HGVS library
-When running the LOVD HGVS library locally, PHP 7.4 and the `json` extension are required.
+When running the LOVD HGVS library locally, PHP 7.4 and the `json` and `zlib` extensions are required.
 It's highly recommended to also have the `mbstring` extension installed.
 
 #### As a standalone tool run directly on the system (e.g., from Bash or Python).

--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -3,3 +3,4 @@ mapping.txt
 NC-variants.txt
 symbol_to_ID.txt
 transcripts.json
+*.gz

--- a/cache/update.php
+++ b/cache/update.php
@@ -115,3 +115,47 @@ if (!$bUpdateCache) {
         echo 'Successfully stored ' . count($aData['transcripts']) . " transcripts.\n";
     }
 }
+
+
+
+
+
+// 3) Load the cytoband data.
+$sCacheFile = 'cytobands.json';
+$bUpdateCache = (!file_exists($sCacheFile));
+
+if (!$bUpdateCache) {
+    echo "Cytoband cache already downloaded.\n";
+} else {
+    $aData = [];
+    foreach (['hg19', 'hg38'] as $sBuild) {
+        $sSource = "https://hgdownload.soe.ucsc.edu/goldenPath/{$sBuild}/database/cytoBand.txt.gz";
+        $aFile = gzfile($sSource, FILE_IGNORE_NEW_LINES);
+        if (!$aFile) {
+            echo "Could not load the remote data for $sBuild.\n";
+            exit(7);
+        }
+
+        foreach ($aFile as $sLine) {
+            list($sChr, $nStart, $nEnd, $sBand) = explode("\t", $sLine);
+            $sChr = substr($sChr, 3); // Remove 'chr' from "chr1".
+            $nStart ++; // UCSC uses 0-based half-open intervals. Fix that, and also convert this to int.
+
+            // Ignore non-relevant "chromosomes".
+            if (!preg_match('/^([XYM]|[0-9]{1,2})$/', $sChr)) {
+                continue;
+            }
+
+            $aData[$sBuild][$sChr][$sBand] = [$nStart, (int) $nEnd];
+        }
+        ksort($aData[$sBuild]);
+    }
+
+    // Now store the file.
+    if (!file_put_contents($sCacheFile, json_encode($aData))) {
+        echo "Could not save the cytoband data.\n";
+        exit(8);
+    } else {
+        echo "Successfully stored cytoband data.\n";
+    }
+}

--- a/cache/update.php
+++ b/cache/update.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2025-04-16
- * Modified    : 2026-02-03
+ * Modified    : 2026-06-05
  *
  * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -150,6 +150,9 @@ if (!$bUpdateCache) {
         }
         ksort($aData[$sBuild]);
     }
+
+    // For some reason, hg19 does not contain the values for chrM.
+    $aData['hg19']['M'] = $aData['hg38']['M'];
 
     // Now store the file.
     if (!file_put_contents($sCacheFile, json_encode($aData))) {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-zlib": "*"
     }
 }


### PR DESCRIPTION
### Add support for CNVs.
- Add classes for chromosome bands, preparing for CNV recognition.
- Add two more classes to depend on: CNV method and copy number.
- Add support for CNV descriptions.
- Deliberately allow Xp, Xq, Yp, and Yq to be a Chromosome.
- Also recognize shorthand descriptions, e.g., `seq(18)x3`.
- Add cytoband data from the UCSC to the project. We can use this for converting ISCN descriptions, but also for determining chromosome lengths.
- Add methods to the ChromosomeBand classes to get the positions. This is based on the data downloaded from the UCSC.
- Add support for, e.g., `seq[GRCh37] del(17)(p13.2)`. The returned positions are based on the chromosome bands given.
- Since we're handling imprecise positions, add parentheses. This turns, e.g., `g.1_100000del` into `g.(1_100000)del`, indicating that the breakpoints haven't been sequenced.
- Make the CNV method matching case-insensitive.
- Add support for a CNV format with four positions. `seq[GRCh37] 4p16.3p15.33(299172x2,331699_13339187x1,13370153x2)` was submitted to us.
- Add support for `seq[GRCh37] Yp11.32Yp11.32(624971_778465)x2`. Having multiple chromosomes in the location description threw off my parsing. When we encounter this, we require the chromosomes to have the same value.
- Add support for `seq[GRCh37] dup(X)(p22.31p22.31)`. This is the same pattern as the `del(X)` format that we already supported, so with a little extra effort, dups are also supported.
- Handle chromosome bands with additional periods. We received `seq[GRCh37] 19p13.2p.13.13(9523950_14142784)x3`.
- Add support for "trp", assuming they are homozygous duplications.
- Add support for more spaces in chromosome bands. We received `seq[GRCh37] 13q12. 11q12.11 (20796833_ 21087890)x0`.
- Add support for `seq[GRCh37] (15)(q13.2q13.3)x1`. I'm not sure if this is official syntax, but we can interpret it.
- Handle unknown cytobands better. Before, when chromosome bands weren't recognized, the corrected value had no positions, e.g., `g.()del`. Now, we just put the cytobands in the output, e.g., `g.(p13.9)del`, if we don't recognize the bands. Also, use `array_unique()` on the positions before imploding, to prevent, e.g., `g.(p13.9_p13.9)del`.
- Improve the output when using "pter" or "qter" as chromosome bands. Make sure we keep "pter" or "qter" in the HGVS description as well.
- When using "qter", adjust the position in the data. We want to have the real position there for that chromosome, not a fake one based on some technical maximum. This also allows us to check maximum positions well for NC variants.
- Fixed the code that processes the UCSC cytoband data. For some reason, hg19 does not contain the values for chrM.
- Use pter and qter as much as we can. This is not just specific for CNVs, but for all chromosomal variant descriptions. We're looking both for refseqs and chromosomes in the variant description, and try to find out the maximum positions. If these are found, we will use pter and qter for 1 and the maximum position, respectively.
- Last small changes, and bump the version number to 1.2.0.